### PR TITLE
[WIP] fix: moving the hardcoded configs in KFPv2 Launcher to configmap. Fixes RHOAIENG-1707

### DIFF
--- a/backend/src/v2/config/env.go
+++ b/backend/src/v2/config/env.go
@@ -29,17 +29,19 @@ import (
 )
 
 const (
-	configMapName                  = "kfp-launcher"
+	configMapName = "kfp-launcher"
+
+	configKeyDefaultPipelineRoot            = "defaultPipelineRoot"
+	configKeydefaultMinioAuthSecretName     = "defaultMiniotAuthSecretName"
+	configKeydefaultMinioSecretAccessKeyKey = "defaultMinioSecretAccessKeyKey"
+	configKeydefaultMinioSecretSecretKeyKey = "defaultMinioSecretSecretKeyKey"
+	configKeyDefaultMinioEndpoint           = "defaultMinioEndpoint"
+
 	defaultPipelineRoot            = "minio://mlpipeline/v2/artifacts"
-	configKeyDefaultPipelineRoot   = "defaultPipelineRoot"
-	minioAuthConfig                = "mlpipeline-minio-artifact"
-	configKeyMinioAuthConfig       = "minioAuthConfig"
-	minioAuthConfigAccessKey       = "accesskey"
-	configMinioAuthConfigAccessKey = "minioAuthConfigAccessKey"
-	minioAuthConfigSecretKey       = "secretkey"
-	configMinioAuthConfigSecretKey = "minioAuthConfigSecretKey"
+	defaultMinioAuthSecretName     = "mlpipeline-minio-artifact"
+	defaultMinioSecretAccessKeyKey = "accesskey"
+	defaultMinioSecretSecretKeyKey = "secretkey"
 	defaultMinioEndpoint           = "minio-service.kubeflow:9000"
-	configDefaultMinioEndpoint     = "defaultMinioEndpoint"
 )
 
 // Config is the KFP runtime configuration.
@@ -72,18 +74,18 @@ func (c *Config) DefaultPipelineRoot() string {
 
 // Config.MinioAuthConfig gets the configured default minio auth config with creds
 func (c *Config) MinioAuthConfig() (string, string, string) {
-	if c == nil || c.data[configKeyMinioAuthConfig] == "" {
-		return minioAuthConfig, minioAuthConfigAccessKey, minioAuthConfigSecretKey
+	if c == nil || c.data[configKeydefaultMinioAuthSecretName] == "" || c.data[configKeydefaultMinioSecretAccessKeyKey] == "" || c.data[configKeydefaultMinioSecretSecretKeyKey] == "" {
+		return defaultMinioAuthSecretName, defaultMinioSecretAccessKeyKey, defaultMinioSecretSecretKeyKey
 	}
-	return c.data[configKeyMinioAuthConfig], c.data[configMinioAuthConfigAccessKey], c.data[configMinioAuthConfigSecretKey]
+	return c.data[configKeydefaultMinioAuthSecretName], c.data[configKeydefaultMinioSecretAccessKeyKey], c.data[configKeydefaultMinioSecretSecretKeyKey]
 }
 
 // Config.MinioAuthConfig gets the configured default minio endpoint
 func (c *Config) MinioEndpoint() string {
-	if c == nil || c.data[configDefaultMinioEndpoint] == "" {
+	if c == nil || c.data[configKeyDefaultMinioEndpoint] == "" {
 		return defaultMinioEndpoint
 	}
-	return c.data[configDefaultMinioEndpoint]
+	return c.data[configKeyDefaultMinioEndpoint]
 }
 
 // InPodNamespace gets current namespace from inside a Kubernetes Pod.

--- a/backend/src/v2/config/env.go
+++ b/backend/src/v2/config/env.go
@@ -29,9 +29,17 @@ import (
 )
 
 const (
-	configMapName                = "kfp-launcher"
-	defaultPipelineRoot          = "minio://mlpipeline/v2/artifacts"
-	configKeyDefaultPipelineRoot = "defaultPipelineRoot"
+	configMapName                  = "kfp-launcher"
+	defaultPipelineRoot            = "minio://mlpipeline/v2/artifacts"
+	configKeyDefaultPipelineRoot   = "defaultPipelineRoot"
+	minioAuthConfig                = "mlpipeline-minio-artifact"
+	configKeyMinioAuthConfig       = "minioAuthConfig"
+	minioAuthConfigAccessKey       = "accesskey"
+	configMinioAuthConfigAccessKey = "minioAuthConfigAccessKey"
+	minioAuthConfigSecretKey       = "secretkey"
+	configMinioAuthConfigSecretKey = "minioAuthConfigSecretKey"
+	defaultMinioEndpoint           = "minio-service.kubeflow:9000"
+	configDefaultMinioEndpoint     = "defaultMinioEndpoint"
 )
 
 // Config is the KFP runtime configuration.
@@ -60,6 +68,22 @@ func (c *Config) DefaultPipelineRoot() string {
 		return defaultPipelineRoot
 	}
 	return c.data[configKeyDefaultPipelineRoot]
+}
+
+// Config.MinioAuthConfig gets the configured default minio auth config with creds
+func (c *Config) MinioAuthConfig() (string, string, string) {
+	if c == nil || c.data[configKeyMinioAuthConfig] == "" {
+		return minioAuthConfig, minioAuthConfigAccessKey, minioAuthConfigSecretKey
+	}
+	return c.data[configKeyMinioAuthConfig], c.data[configMinioAuthConfigAccessKey], c.data[configMinioAuthConfigSecretKey]
+}
+
+// Config.MinioAuthConfig gets the configured default minio endpoint
+func (c *Config) MinioEndpoint() string {
+	if c == nil || c.data[configDefaultMinioEndpoint] == "" {
+		return defaultMinioEndpoint
+	}
+	return c.data[configDefaultMinioEndpoint]
 }
 
 // InPodNamespace gets current namespace from inside a Kubernetes Pod.

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -185,22 +185,25 @@ func Test_GetMinioDefaultEndpoint(t *testing.T) {
 		os.Unsetenv("MINIO_SERVICE_SERVICE_PORT")
 	}()
 	tests := []struct {
-		name                string
-		minioServiceHostEnv string
-		minioServicePortEnv string
-		want                string
+		name                 string
+		minioServiceHostEnv  string
+		minioServicePortEnv  string
+		defaultMinioEndpoint string
+		want                 string
 	}{
 		{
-			name:                "In full Kubeflow, KFP multi-user mode on",
-			minioServiceHostEnv: "",
-			minioServicePortEnv: "",
-			want:                "minio-service.kubeflow:9000",
+			name:                 "In full Kubeflow, KFP multi-user mode on",
+			minioServiceHostEnv:  "",
+			minioServicePortEnv:  "",
+			defaultMinioEndpoint: "minio-service.kubeflow:9000",
+			want:                 "minio-service.kubeflow:9000",
 		},
 		{
-			name:                "In KFP standalone without multi-user mode",
-			minioServiceHostEnv: "1.2.3.4",
-			minioServicePortEnv: "4321",
-			want:                "1.2.3.4:4321",
+			name:                 "In KFP standalone without multi-user mode",
+			minioServiceHostEnv:  "1.2.3.4",
+			minioServicePortEnv:  "4321",
+			defaultMinioEndpoint: "minio-service.kubeflow:9000",
+			want:                 "1.2.3.4:4321",
 		},
 	}
 	for _, tt := range tests {
@@ -215,10 +218,10 @@ func Test_GetMinioDefaultEndpoint(t *testing.T) {
 			} else {
 				os.Unsetenv("MINIO_SERVICE_SERVICE_PORT")
 			}
-			got := objectstore.MinioDefaultEndpoint()
+			got := objectstore.MinioDefaultEndpoint(tt.defaultMinioEndpoint)
 			if got != tt.want {
 				t.Errorf(
-					"MinioDefaultEndpoint() = %q, want %q\nwhen MINIO_SERVICE_SERVICE_HOST=%q MINIO_SERVICE_SERVICE_PORT=%q",
+					"MinioDefaultEndpoint(tt.defaultMinioEndpoint) = %q, want %q\nwhen MINIO_SERVICE_SERVICE_HOST=%q MINIO_SERVICE_SERVICE_PORT=%q",
 					got, tt.want, tt.minioServiceHostEnv, tt.minioServicePortEnv,
 				)
 			}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves https://issues.redhat.com/browse/RHOAIENG-1707

**Description of your changes:**
Followed Option 1 in the suggestion mentioned in kubeflow/pipelines/issues/9689

> We want to allow the above configs to be changed from their defaults, preferably on a per-namespace basis.
> 
> I propose we add these configs to the ConfigMap/kfp-launcher which already exists in each profile namespace to set defaultPipelineRoot.
> 
> For example, a new ConfigMap/kfp-launcher in a profile namespace might look like this:
> ```
> data:
>   defaultPipelineRoot: "minio://mlpipeline/v2/artifacts"
>  
>   ## minio endpoint config
>   defaultMinioEndpoint: "minio.example.com:9000"
>  
>   ## minio auth configs
>   minioAuthConfig: "mlpipeline-minio-artifact"
>   minioAuthConfigAccessKey: "access_key"
>   minioAuthConfigSecretKey: "access_key"
> ```
> 
> OPTION 1: have the kfp-launcher container read the ConfigMap/kfp-launcher
> [when it executes](https://github.com/kubeflow/pipelines/blob/dbebbde2001f7d2a7372a8abfd9c5c5a0eaea2b8/backend/src/v2/component/launcher_v2.go#L132), it can pass the minio configs down as it calls [objectstore.OpenBucket](https://github.com/kubeflow/pipelines/blob/dbebbde2001f7d2a7372a8abfd9c5c5a0eaea2b8/backend/src/v2/component/launcher_v2.go#L163)

**Environment tested:**


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
