### PR TITLE
add configurable ml pipeline

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -32,6 +32,15 @@ const (
 	KubeflowUserIDPrefix                    string = "KUBEFLOW_USERID_PREFIX"
 	UpdatePipelineVersionByDefault          string = "AUTO_UPDATE_PIPELINE_DEFAULT_VERSION"
 	TokenReviewAudience                     string = "TOKEN_REVIEW_AUDIENCE"
+
+	// Discover ml-pipeline in the same namespace by env var.
+	// https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables
+	// If there is a ml-pipeline Kubernetes service in the same namespace,
+	// ML_PIPELINE_SERVICE_HOST and ML_PIPELINE_SERVICE_PORT env vars should
+	// exist by default, so we use it as default. If using a service name that is not ml-pipeline
+	// these env vars should be manually provided.
+	mlPipelineServiceAddress  string = "ML_PIPELINE_SERVICE_HOST"
+	mlPipelineServiceGRPCPort string = "ML_PIPELINE_SERVICE_PORT_GRPC"
 )
 
 func IsPipelineVersionUpdatedByDefault() bool {
@@ -126,4 +135,12 @@ func GetKubeflowUserIDPrefix() string {
 
 func GetTokenReviewAudience() string {
 	return GetStringConfigWithDefault(TokenReviewAudience, DefaultTokenReviewAudience)
+}
+
+func GetMLPipelineServiceAddress() string {
+	return GetStringConfigWithDefault(mlPipelineServiceAddress, DefaultMLPipelineAddress)
+}
+
+func GetMlPipelineServiceGRPCPort() string {
+	return GetStringConfigWithDefault(mlPipelineServiceGRPCPort, DefaultMLPipelineGRPCPort)
 }

--- a/backend/src/apiserver/common/const.go
+++ b/backend/src/apiserver/common/const.go
@@ -55,6 +55,8 @@ const DefaultTokenReviewAudience string = "pipelines.kubeflow.org"
 
 const (
 	DefaultPipelineRunnerServiceAccount = "pipeline-runner"
+	DefaultMLPipelineAddress            = "ml-pipeline.kubeflow"
+	DefaultMLPipelineGRPCPort           = "8887"
 	HasDefaultBucketEnvVar              = "HAS_DEFAULT_BUCKET"
 	DefaultBucketNameEnvVar             = "BUCKET_NAME"
 	ProjectIDEnvVar                     = "PROJECT_ID"

--- a/backend/src/v2/cmd/launcher-v2/main.go
+++ b/backend/src/v2/cmd/launcher-v2/main.go
@@ -27,20 +27,22 @@ import (
 
 // TODO: use https://github.com/spf13/cobra as a framework to create more complex CLI tools with subcommands.
 var (
-	copy              = flag.String("copy", "", "copy this binary to specified destination path")
-	pipelineName      = flag.String("pipeline_name", "", "pipeline context name")
-	runID             = flag.String("run_id", "", "pipeline run uid")
-	parentDagID       = flag.Int64("parent_dag_id", 0, "parent DAG execution ID")
-	executorType      = flag.String("executor_type", "container", "The type of the ExecutorSpec")
-	executionID       = flag.Int64("execution_id", 0, "Execution ID of this task.")
-	executorInputJSON = flag.String("executor_input", "", "The JSON-encoded ExecutorInput.")
-	componentSpecJSON = flag.String("component_spec", "", "The JSON-encoded ComponentSpec.")
-	importerSpecJSON  = flag.String("importer_spec", "", "The JSON-encoded ImporterSpec.")
-	taskSpecJSON      = flag.String("task_spec", "", "The JSON-encoded TaskSpec.")
-	podName           = flag.String("pod_name", "", "Kubernetes Pod name.")
-	podUID            = flag.String("pod_uid", "", "Kubernetes Pod UID.")
-	mlmdServerAddress = flag.String("mlmd_server_address", "", "The MLMD gRPC server address.")
-	mlmdServerPort    = flag.String("mlmd_server_port", "8080", "The MLMD gRPC server port.")
+	copy                     = flag.String("copy", "", "copy this binary to specified destination path")
+	pipelineName             = flag.String("pipeline_name", "", "pipeline context name")
+	runID                    = flag.String("run_id", "", "pipeline run uid")
+	parentDagID              = flag.Int64("parent_dag_id", 0, "parent DAG execution ID")
+	executorType             = flag.String("executor_type", "container", "The type of the ExecutorSpec")
+	executionID              = flag.Int64("execution_id", 0, "Execution ID of this task.")
+	executorInputJSON        = flag.String("executor_input", "", "The JSON-encoded ExecutorInput.")
+	componentSpecJSON        = flag.String("component_spec", "", "The JSON-encoded ComponentSpec.")
+	importerSpecJSON         = flag.String("importer_spec", "", "The JSON-encoded ImporterSpec.")
+	taskSpecJSON             = flag.String("task_spec", "", "The JSON-encoded TaskSpec.")
+	podName                  = flag.String("pod_name", "", "Kubernetes Pod name.")
+	podUID                   = flag.String("pod_uid", "", "Kubernetes Pod UID.")
+	mlmdServerAddress        = flag.String("mlmd_server_address", "", "The MLMD gRPC server address.")
+	mlmdServerPort           = flag.String("mlmd_server_port", "8080", "The MLMD gRPC server port.")
+	mlPipelineServerAddress  = flag.String("ml_pipeline_server_address", "ml-pipeline.kubeflow.svc.cluster.local", "ML Pipeline server address")
+	mlPipelineServerGrpcPort = flag.String("ml_pipeline_server_grpc_port", "8887", "ML Pipeline server grpc port")
 )
 
 func main() {
@@ -65,13 +67,15 @@ func run() error {
 		return err
 	}
 	launcherV2Opts := &component.LauncherV2Options{
-		Namespace:         namespace,
-		PodName:           *podName,
-		PodUID:            *podUID,
-		MLMDServerAddress: *mlmdServerAddress,
-		MLMDServerPort:    *mlmdServerPort,
-		PipelineName:      *pipelineName,
-		RunID:             *runID,
+		Namespace:                namespace,
+		PodName:                  *podName,
+		PodUID:                   *podUID,
+		MLMDServerAddress:        *mlmdServerAddress,
+		MLMDServerPort:           *mlmdServerPort,
+		MLPipelineServerAddress:  *mlPipelineServerAddress,
+		MLPipelineServerGrpcPort: *mlPipelineServerGrpcPort,
+		PipelineName:             *pipelineName,
+		RunID:                    *runID,
 	}
 
 	switch *executorType {

--- a/backend/src/v2/compiler/argocompiler/argo.go
+++ b/backend/src/v2/compiler/argocompiler/argo.go
@@ -16,6 +16,7 @@ package argocompiler
 
 import (
 	"fmt"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"strings"
 
 	wfapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -116,11 +117,13 @@ func Compile(jobArg *pipelinespec.PipelineJob, kubernetesSpecArg *pipelinespec.S
 		wf:        wf,
 		templates: make(map[string]*wfapi.Template),
 		// TODO(chensun): release process and update the images.
-		launcherImage: GetLauncherImage(),
-		driverImage:   GetDriverImage(),
-		job:           job,
-		spec:          spec,
-		executors:     deploy.GetExecutors(),
+		launcherImage:            GetLauncherImage(),
+		driverImage:              GetDriverImage(),
+		job:                      job,
+		spec:                     spec,
+		executors:                deploy.GetExecutors(),
+		mlPipelineServerAddress:  common.GetMLPipelineServiceAddress(),
+		mlPipelineServerGrpcPort: common.GetMlPipelineServiceGRPCPort(),
 	}
 	if opts != nil {
 		if opts.DriverImage != "" {
@@ -151,10 +154,12 @@ type workflowCompiler struct {
 	spec      *pipelinespec.PipelineSpec
 	executors map[string]*pipelinespec.PipelineDeploymentConfig_ExecutorSpec
 	// state
-	wf            *wfapi.Workflow
-	templates     map[string]*wfapi.Template
-	driverImage   string
-	launcherImage string
+	wf                       *wfapi.Workflow
+	templates                map[string]*wfapi.Template
+	driverImage              string
+	launcherImage            string
+	mlPipelineServerAddress  string
+	mlPipelineServerGrpcPort string
 }
 
 func (c *workflowCompiler) Resolver(name string, component *pipelinespec.ComponentSpec, resolver *pipelinespec.PipelineDeploymentConfig_ResolverSpec) error {

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -16,18 +16,18 @@ package argocompiler
 
 import (
 	wfapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
-	"os"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/v2/component"
 	k8score "k8s.io/api/core/v1"
+	"os"
 )
 
 const (
 	volumeNameKFPLauncher = "kfp-launcher"
-	DefaultLauncherImage = "gcr.io/ml-pipeline/kfp-launcher@sha256:80cf120abd125db84fa547640fd6386c4b2a26936e0c2b04a7d3634991a850a4"
+	DefaultLauncherImage  = "gcr.io/ml-pipeline/kfp-launcher@sha256:80cf120abd125db84fa547640fd6386c4b2a26936e0c2b04a7d3634991a850a4"
 	LauncherImageEnvVar   = "V2_LAUNCHER_IMAGE"
-	DefaultDriverImage = "gcr.io/ml-pipeline/kfp-driver@sha256:8e60086b04d92b657898a310ca9757631d58547e76bbbb8bfc376d654bef1707"
-	DriverImageEnvVar   = "V2_DRIVER_IMAGE"
+	DefaultDriverImage    = "gcr.io/ml-pipeline/kfp-driver@sha256:8e60086b04d92b657898a310ca9757631d58547e76bbbb8bfc376d654bef1707"
+	DriverImageEnvVar     = "V2_DRIVER_IMAGE"
 )
 
 func (c *workflowCompiler) Container(name string, component *pipelinespec.ComponentSpec, container *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec) error {
@@ -58,19 +58,19 @@ type containerDriverInputs struct {
 }
 
 func GetLauncherImage() string {
-    launcherImage := os.Getenv(LauncherImageEnvVar)
-    if launcherImage == "" {
-        launcherImage = DefaultLauncherImage
-    }
-    return launcherImage
+	launcherImage := os.Getenv(LauncherImageEnvVar)
+	if launcherImage == "" {
+		launcherImage = DefaultLauncherImage
+	}
+	return launcherImage
 }
 
 func GetDriverImage() string {
-    driverImage := os.Getenv(DriverImageEnvVar)
-    if driverImage == "" {
-        driverImage = DefaultDriverImage
-    }
-    return driverImage
+	driverImage := os.Getenv(DriverImageEnvVar)
+	if driverImage == "" {
+		driverImage = DefaultDriverImage
+	}
+	return driverImage
 }
 
 func (c *workflowCompiler) containerDriverTask(name string, inputs containerDriverInputs) (*wfapi.DAGTask, *containerDriverOutputs) {
@@ -147,6 +147,8 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 				"--pod_spec_patch_path", outputPath(paramPodSpecPatch),
 				"--condition_path", outputPath(paramCondition),
 				"--kubernetes_config", inputValue(paramKubernetesConfig),
+				"--ml_pipeline_server_address", c.mlPipelineServerAddress,
+				"--ml_pipeline_server_grpc_port", c.mlPipelineServerGrpcPort,
 			},
 			Resources: driverResources,
 		},

--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -440,6 +440,8 @@ func (c *workflowCompiler) addDAGDriverTemplate() string {
 				"--execution_id_path", outputPath(paramExecutionID),
 				"--iteration_count_path", outputPath(paramIterationCount),
 				"--condition_path", outputPath(paramCondition),
+				"--ml_pipeline_server_address", c.mlPipelineServerAddress,
+				"--ml_pipeline_server_grpc_port", c.mlPipelineServerGrpcPort,
 			},
 			Resources: driverResources,
 		},

--- a/backend/src/v2/compiler/argocompiler/importer.go
+++ b/backend/src/v2/compiler/argocompiler/importer.go
@@ -80,6 +80,8 @@ func (c *workflowCompiler) addImporterTemplate() string {
 		fmt.Sprintf("$(%s)", component.EnvMetadataHost),
 		"--mlmd_server_port",
 		fmt.Sprintf("$(%s)", component.EnvMetadataPort),
+		"--ml_pipeline_server_address", c.mlPipelineServerAddress,
+		"--ml_pipeline_server_grpc_port", c.mlPipelineServerGrpcPort,
 	}
 	importerTemplate := &wfapi.Template{
 		Name: name,

--- a/backend/src/v2/compiler/argocompiler/testdata/create_mount_delete_dynamic_pvc.yaml
+++ b/backend/src/v2/compiler/argocompiler/testdata/create_mount_delete_dynamic_pvc.yaml
@@ -65,6 +65,10 @@ spec:
       - '{{outputs.parameters.condition.path}}'
       - --kubernetes_config
       - '{{inputs.parameters.kubernetes-config}}'
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_grpc_port
+      - 8887
       command:
       - driver
       image: gcr.io/ml-pipeline/kfp-driver
@@ -275,6 +279,10 @@ spec:
       - '{{outputs.parameters.iteration-count.path}}'
       - --condition_path
       - '{{outputs.parameters.condition.path}}'
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_grpc_port
+      - 8887
       command:
       - driver
       image: gcr.io/ml-pipeline/kfp-driver

--- a/backend/src/v2/compiler/argocompiler/testdata/hello_world.yaml
+++ b/backend/src/v2/compiler/argocompiler/testdata/hello_world.yaml
@@ -48,6 +48,10 @@ spec:
       - '{{outputs.parameters.condition.path}}'
       - --kubernetes_config
       - '{{inputs.parameters.kubernetes-config}}'
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_grpc_port
+      - 8887
       command:
       - driver
       image: gcr.io/ml-pipeline/kfp-driver
@@ -205,6 +209,10 @@ spec:
       - '{{outputs.parameters.iteration-count.path}}'
       - --condition_path
       - '{{outputs.parameters.condition.path}}'
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_grpc_port
+      - 8887
       command:
       - driver
       image: gcr.io/ml-pipeline/kfp-driver

--- a/backend/src/v2/compiler/argocompiler/testdata/importer.yaml
+++ b/backend/src/v2/compiler/argocompiler/testdata/importer.yaml
@@ -41,6 +41,10 @@ spec:
       - $(METADATA_GRPC_SERVICE_HOST)
       - --mlmd_server_port
       - $(METADATA_GRPC_SERVICE_PORT)
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_grpc_port
+      - 8887
       command:
       - launcher-v2
       env:
@@ -118,6 +122,10 @@ spec:
       - '{{outputs.parameters.iteration-count.path}}'
       - --condition_path
       - '{{outputs.parameters.condition.path}}'
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_grpc_port
+      - 8887
       command:
       - driver
       image: gcr.io/ml-pipeline/kfp-driver

--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -50,6 +50,8 @@ type LauncherV2Options struct {
 	PodUID,
 	MLMDServerAddress,
 	MLMDServerPort,
+	MLPipelineServerAddress,
+	MLPipelineServerGrpcPort,
 	PipelineName,
 	RunID string
 }
@@ -112,7 +114,9 @@ func NewLauncherV2(ctx context.Context, executionID int64, executorInputJSON, co
 	if err != nil {
 		return nil, err
 	}
-	cacheClient, err := cacheutils.NewClient()
+
+	mlPipelineEndpoint := opts.MLPipelineServerAddress + ":" + opts.MLPipelineServerGrpcPort
+	cacheClient, err := cacheutils.NewClient(mlPipelineEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -29,12 +29,14 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 	viper.Set("KFP_POD_NAME", "MyWorkflowPod")
 	viper.Set("KFP_POD_UID", "a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6")
 	type args struct {
-		container     *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec
-		componentSpec *pipelinespec.ComponentSpec
-		executorInput *pipelinespec.ExecutorInput
-		executionID   int64
-		pipelineName  string
-		runID         string
+		container                *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec
+		componentSpec            *pipelinespec.ComponentSpec
+		executorInput            *pipelinespec.ExecutorInput
+		executionID              int64
+		pipelineName             string
+		runID                    string
+		mlPipelineServerAddress  string
+		mlPipelineServerGrpcPort string
 	}
 	tests := []struct {
 		name    string
@@ -77,6 +79,8 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 				1,
 				"MyPipeline",
 				"a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6",
+				"",
+				"",
 			},
 			`"nvidia.com/gpu":"1"`,
 			false,
@@ -116,6 +120,8 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 				1,
 				"MyPipeline",
 				"a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6",
+				"",
+				"",
 			},
 			`"amd.com/gpu":"1"`,
 			false,
@@ -155,6 +161,8 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 				1,
 				"MyPipeline",
 				"a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6",
+				"",
+				"",
 			},
 			`"cloud-tpus.google.com/v3":"1"`,
 			false,
@@ -194,6 +202,8 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 				1,
 				"MyPipeline",
 				"a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6",
+				"",
+				"",
 			},
 			`"cloud-tpus.google.com/v2":"1"`,
 			false,
@@ -233,6 +243,8 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 				1,
 				"MyPipeline",
 				"a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6",
+				"",
+				"",
 			},
 			`"custom.example.com/accelerator-v1":"1"`,
 			false,
@@ -241,7 +253,9 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			podSpec, err := initPodSpecPatch(tt.args.container, tt.args.componentSpec, tt.args.executorInput, tt.args.executionID, tt.args.pipelineName, tt.args.runID)
+			podSpec, err := initPodSpecPatch(tt.args.container, tt.args.componentSpec, tt.args.executorInput,
+				tt.args.executionID, tt.args.pipelineName, tt.args.runID, tt.args.mlPipelineServerAddress,
+				tt.args.mlPipelineServerGrpcPort)
 			if tt.wantErr {
 				assert.Nil(t, podSpec)
 				assert.NotNil(t, err)
@@ -315,12 +329,14 @@ func Test_initPodSpecPatch_resourceRequests(t *testing.T) {
 	viper.Set("KFP_POD_NAME", "MyWorkflowPod")
 	viper.Set("KFP_POD_UID", "a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6")
 	type args struct {
-		container     *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec
-		componentSpec *pipelinespec.ComponentSpec
-		executorInput *pipelinespec.ExecutorInput
-		executionID   int64
-		pipelineName  string
-		runID         string
+		container                *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec
+		componentSpec            *pipelinespec.ComponentSpec
+		executorInput            *pipelinespec.ExecutorInput
+		executionID              int64
+		pipelineName             string
+		runID                    string
+		mlPipelineServerAddress  string
+		mlPipelineServerGrpcPort string
 	}
 	tests := []struct {
 		name    string
@@ -360,6 +376,8 @@ func Test_initPodSpecPatch_resourceRequests(t *testing.T) {
 				1,
 				"MyPipeline",
 				"a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6",
+				"",
+				"",
 			},
 			`"resources":{"limits":{"cpu":"2","memory":"1500M"},"requests":{"cpu":"1","memory":"650M"}}`,
 			"",
@@ -396,6 +414,8 @@ func Test_initPodSpecPatch_resourceRequests(t *testing.T) {
 				1,
 				"MyPipeline",
 				"a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6",
+				"",
+				"",
 			},
 			`"resources":{"limits":{"cpu":"2","memory":"1500M"}}`,
 			`"requests"`,
@@ -403,7 +423,9 @@ func Test_initPodSpecPatch_resourceRequests(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			podSpec, err := initPodSpecPatch(tt.args.container, tt.args.componentSpec, tt.args.executorInput, tt.args.executionID, tt.args.pipelineName, tt.args.runID)
+			podSpec, err := initPodSpecPatch(tt.args.container, tt.args.componentSpec, tt.args.executorInput,
+				tt.args.executionID, tt.args.pipelineName, tt.args.runID, tt.args.mlPipelineServerAddress,
+				tt.args.mlPipelineServerGrpcPort)
 			assert.Nil(t, err)
 			assert.NotEmpty(t, podSpec)
 			podSpecString, err := json.Marshal(podSpec)


### PR DESCRIPTION
Part of: https://issues.redhat.com/browse/RHOAIENG-1707

use the following dspa to test the changes: 


<details>

<summary>dspa.yaml</summary>


```yaml
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
spec:
  dspVersion: v2
  apiServer:
    deploy: true
    image: quay.io/hukhan/ds-pipelines-api-server:dynamic-ml-endpoint-1
    argoLauncherImage: quay.io/hukhan/kfp-launcher:dynamic-ml-endpoint-1
    argoDriverImage: quay.io/hukhan/kfp-driver:dynamic-ml-endpoint-1
  persistenceAgent:
    deploy: true
    image: gcr.io/ml-pipeline/persistenceagent:2.0.2
  scheduledWorkflow:
    deploy: true
    image: gcr.io/ml-pipeline/scheduledworkflow:2.0.2
  mlmd:
    deploy: true
    grpc:
      image: gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0
    envoy:
      image: gcr.io/ml-pipeline/metadata-envoy:2.0.2
  database:
    disableHealthCheck: true
    mariaDB:
      deploy: true
  objectStorage:
    minio:
      deploy: true
      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
  mlpipelineUI:
    image: gcr.io/ml-pipeline/frontend:2.0.2
  workflowController:
    deploy: true
    image: gcr.io/ml-pipeline/workflow-controller:v3.3.10-license-compliance
```

</details>