### PR TITLE
UPSTREAM: <carry>: add ns scoped s3 support.

### DIFF
--- a/backend/src/v2/component/importer_launcher.go
+++ b/backend/src/v2/component/importer_launcher.go
@@ -111,7 +111,7 @@ func (l *ImportLauncher) Execute(ctx context.Context) (err error) {
 	}()
 	// TODO(Bobgy): there's no need to pass any parameters, because pipeline
 	// and pipeline run context have been created by root DAG driver.
-	pipeline, err := l.metadataClient.GetPipeline(ctx, l.importerLauncherOptions.PipelineName, l.importerLauncherOptions.RunID, "", "", "")
+	pipeline, err := l.metadataClient.GetPipeline(ctx, l.importerLauncherOptions.PipelineName, l.importerLauncherOptions.RunID, "", "", "", "")
 	if err != nil {
 		return err
 	}

--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -160,7 +160,8 @@ func (l *LauncherV2) Execute(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	bucket, err := objectstore.OpenBucket(ctx, l.k8sClient, l.options.Namespace, bucketConfig)
+	bucketSessionInfo := execution.GetPipeline().GetPipelineBucketSession()
+	bucket, err := objectstore.OpenBucket(ctx, l.k8sClient, l.options.Namespace, bucketConfig, bucketSessionInfo)
 	if err != nil {
 		return err
 	}
@@ -539,7 +540,7 @@ func fetchNonDefaultBuckets(
 			if err != nil {
 				return nonDefaultBuckets, fmt.Errorf("failed to parse bucketConfig for output artifact %q with uri %q: %w", name, artifact.GetUri(), err)
 			}
-			nonDefaultBucket, err := objectstore.OpenBucket(ctx, k8sClient, namespace, nonDefaultBucketConfig)
+			nonDefaultBucket, err := objectstore.OpenBucket(ctx, k8sClient, namespace, nonDefaultBucketConfig, "")
 			if err != nil {
 				return nonDefaultBuckets, fmt.Errorf("failed to open bucket for output artifact %q with uri %q: %w", name, artifact.GetUri(), err)
 			}

--- a/backend/src/v2/config/env.go
+++ b/backend/src/v2/config/env.go
@@ -19,7 +19,9 @@ package config
 import (
 	"context"
 	"fmt"
+	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 	"io/ioutil"
+	"sigs.k8s.io/yaml"
 	"strings"
 
 	"github.com/golang/glog"
@@ -81,4 +83,179 @@ func InPodName() (string, error) {
 	}
 	name := string(podName)
 	return strings.TrimSuffix(name, "\n"), nil
+}
+
+const (
+	configBucketProviders = "providers"
+	// The endpoint uses Kubernetes service DNS name with namespace:
+	// https://kubernetes.io/docs/concepts/services-networking/service/#dns
+	defaultMinioEndpointInMultiUserMode = "minio-service.kubeflow:9000"
+	minioArtifactSecretName             = "mlpipeline-minio-artifact"
+	minioArtifactSecretKeyKey           = "secretkey"
+	minioArtifactAccessKeyKey           = "accesskey"
+)
+
+type BucketProviders struct {
+	Minio *ProviderConfig `json:"minio"`
+	S3    *ProviderConfig `json:"s3"`
+	GCS   *ProviderConfig `json:"gcs"`
+}
+
+type ProviderConfig struct {
+	Endpoint                 string     `json:"endpoint"`
+	DefaultProviderSecretRef *SecretRef `json:"defaultProviderSecretRef"`
+	Region                   string     `json:"region"`
+	// optional
+	DisableSSL bool `json:"disableSSL"`
+	// optional, ordered, the auth config for the first matching prefix is used
+	AuthConfigs []AuthConfig `json:"authConfigs"`
+}
+
+type AuthConfig struct {
+	BucketName string `json:"bucketName"`
+	KeyPrefix  string `json:"keyPrefix"`
+	*SecretRef `json:"secretRef"`
+}
+
+type SecretRef struct {
+	SecretName   string `json:"secretName"`
+	AccessKeyKey string `json:"accessKeyKey"`
+	SecretKeyKey string `json:"secretKeyKey"`
+}
+
+func (c *Config) GetBucketSessionInfo() (objectstore.SessionInfo, error) {
+	path := c.DefaultPipelineRoot()
+	bucketConfig, err := objectstore.ParseBucketConfig(path)
+	if err != nil {
+		return objectstore.SessionInfo{}, err
+	}
+	bucketName := bucketConfig.BucketName
+	bucketPrefix := bucketConfig.Prefix
+	provider := strings.TrimSuffix(bucketConfig.Scheme, "://")
+	bucketProviders, err := c.getBucketProviders()
+	if err != nil {
+		return objectstore.SessionInfo{}, err
+	}
+
+	// Case 1: No "providers" field in kfp-launcher
+	if bucketProviders == nil {
+		// Use default minio if provider is minio, otherwise we default to executor env
+		if provider == "minio" {
+			return getDefaultMinioSessionInfo(), nil
+		} else {
+			// If not using minio, and no other provider config is provided
+			// rely on executor env (e.g. IRSA) for authenticating with provider
+			return objectstore.SessionInfo{}, nil
+		}
+	}
+
+	var providerConfig *ProviderConfig
+	switch provider {
+	case "minio":
+		providerConfig = bucketProviders.Minio
+		break
+	case "s3":
+		providerConfig = bucketProviders.S3
+		break
+	case "gs":
+		providerConfig = bucketProviders.Minio
+		break
+	default:
+		return objectstore.SessionInfo{}, fmt.Errorf("Encountered unsupported provider in BucketProviders %s", provider)
+	}
+
+	// Case 2: "providers" field is empty {}
+	if providerConfig == nil {
+		if provider == "minio" {
+			return getDefaultMinioSessionInfo(), nil
+		} else {
+			return objectstore.SessionInfo{}, nil
+		}
+	}
+
+	// Case 3: a provider is specified
+	endpoint := providerConfig.Endpoint
+	if endpoint == "" {
+		if provider == "minio" {
+			endpoint = objectstore.MinioDefaultEndpoint()
+		} else {
+			return objectstore.SessionInfo{}, fmt.Errorf("Invalid provider config, %s.defaultProviderSecretRef is required for this storage provider", provider)
+		}
+	}
+
+	// DefaultProviderSecretRef takes precedent over other configs
+	secretRef := providerConfig.DefaultProviderSecretRef
+	if secretRef == nil {
+		if provider == "minio" {
+			secretRef = &SecretRef{
+				SecretName:   minioArtifactSecretName,
+				SecretKeyKey: minioArtifactSecretKeyKey,
+				AccessKeyKey: minioArtifactAccessKeyKey,
+			}
+		} else {
+			return objectstore.SessionInfo{}, fmt.Errorf("Invalid provider config, %s.defaultProviderSecretRef is required for this storage provider", provider)
+		}
+	}
+
+	// if not provided, defaults to false
+	disableSSL := providerConfig.DisableSSL
+
+	region := providerConfig.Region
+	if region == "" {
+		return objectstore.SessionInfo{}, fmt.Errorf("Invalid provider config, missing provider region")
+	}
+
+	// if another secret is specified for a given bucket/prefix then that takes
+	// higher precedent over DefaultProviderSecretRef
+	authConfig := getBucketAuthByPrefix(providerConfig.AuthConfigs, bucketName, bucketPrefix)
+	if authConfig != nil {
+		if authConfig.SecretRef == nil || authConfig.SecretRef.SecretKeyKey == "" || authConfig.SecretRef.AccessKeyKey == "" || authConfig.SecretRef.SecretName == "" {
+			return objectstore.SessionInfo{}, fmt.Errorf("Invalid provider config, %s.AuthConfigs[].secretConfig is missing or invalid", provider)
+		}
+		secretRef = authConfig.SecretRef
+	}
+
+	return objectstore.SessionInfo{
+		Region:       region,
+		Endpoint:     endpoint,
+		DisableSSL:   disableSSL,
+		SecretName:   secretRef.SecretName,
+		AccessKeyKey: secretRef.AccessKeyKey,
+		SecretKeyKey: secretRef.SecretKeyKey,
+	}, nil
+}
+
+func getDefaultMinioSessionInfo() (sessionInfo objectstore.SessionInfo) {
+	sess := objectstore.SessionInfo{
+		Region:       "minio",
+		Endpoint:     objectstore.MinioDefaultEndpoint(),
+		DisableSSL:   true,
+		SecretName:   minioArtifactSecretName,
+		AccessKeyKey: minioArtifactAccessKeyKey,
+		SecretKeyKey: minioArtifactSecretKeyKey,
+	}
+	return sess
+}
+
+// getBucketProviders gets the provider configuration
+func (c *Config) getBucketProviders() (*BucketProviders, error) {
+	if c == nil || c.data[configBucketProviders] == "" {
+		return nil, nil
+	}
+	bucketProviders := &BucketProviders{}
+	configAuth := c.data[configBucketProviders]
+	err := yaml.Unmarshal([]byte(configAuth), bucketProviders)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshall kfp bucket providers, ensure that providers config is well formed: %w", err)
+	}
+	return bucketProviders, nil
+}
+
+func getBucketAuthByPrefix(authConfigs []AuthConfig, bucketName, prefix string) *AuthConfig {
+	for _, authConfig := range authConfigs {
+		if authConfig.BucketName == bucketName && (authConfig.KeyPrefix == prefix) {
+			return &authConfig
+		}
+	}
+	return nil
 }

--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -77,7 +77,7 @@ var (
 )
 
 type ClientInterface interface {
-	GetPipeline(ctx context.Context, pipelineName, runID, namespace, runResource, pipelineRoot string) (*Pipeline, error)
+	GetPipeline(ctx context.Context, pipelineName, runID, namespace, runResource, pipelineRoot, bucketSessionInfo string) (*Pipeline, error)
 	GetDAG(ctx context.Context, executionID int64) (*DAG, error)
 	PublishExecution(ctx context.Context, execution *Execution, outputParameters map[string]*structpb.Value, outputArtifacts []*OutputArtifact, state pb.Execution_State) error
 	CreateExecution(ctx context.Context, pipeline *Pipeline, config *ExecutionConfig) (*Execution, error)
@@ -200,6 +200,18 @@ func (p *Pipeline) GetCtxID() int64 {
 	return p.pipelineCtx.GetId()
 }
 
+func (p *Pipeline) GetPipelineBucketSession() string {
+	if p == nil {
+		return ""
+	}
+	props := p.pipelineRunCtx.GetCustomProperties()
+	bucketSessionInfo, ok := props[keySessionInfoDetails]
+	if !ok {
+		return ""
+	}
+	return bucketSessionInfo.GetStringValue()
+}
+
 func (p *Pipeline) GetPipelineRoot() string {
 	if p == nil {
 		return ""
@@ -262,7 +274,7 @@ func (e *Execution) FingerPrint() string {
 
 // GetPipeline returns the current pipeline represented by the specified
 // pipeline name and run ID.
-func (c *Client) GetPipeline(ctx context.Context, pipelineName, runID, namespace, runResource, pipelineRoot string) (*Pipeline, error) {
+func (c *Client) GetPipeline(ctx context.Context, pipelineName, runID, namespace, runResource, pipelineRoot, bucketSessionInfo string) (*Pipeline, error) {
 	pipelineContext, err := c.getOrInsertContext(ctx, pipelineName, pipelineContextType, nil)
 	if err != nil {
 		return nil, err
@@ -272,7 +284,8 @@ func (c *Client) GetPipeline(ctx context.Context, pipelineName, runID, namespace
 		keyNamespace:    stringValue(namespace),
 		keyResourceName: stringValue(runResource),
 		// pipeline root of this run
-		keyPipelineRoot: stringValue(strings.TrimRight(pipelineRoot, "/") + "/" + path.Join(pipelineName, runID)),
+		keyPipelineRoot:       stringValue(strings.TrimRight(pipelineRoot, "/") + "/" + path.Join(pipelineName, runID)),
+		keySessionInfoDetails: stringValue(bucketSessionInfo),
 	}
 	runContext, err := c.getOrInsertContext(ctx, runID, pipelineRunContextType, metadata)
 	glog.Infof("Pipeline Run Context: %+v", runContext)
@@ -464,21 +477,22 @@ func (c *Client) PublishExecution(ctx context.Context, execution *Execution, out
 
 // metadata keys
 const (
-	keyDisplayName       = "display_name"
-	keyTaskName          = "task_name"
-	keyImage             = "image"
-	keyPodName           = "pod_name"
-	keyPodUID            = "pod_uid"
-	keyNamespace         = "namespace"
-	keyResourceName      = "resource_name"
-	keyPipelineRoot      = "pipeline_root"
-	keyCacheFingerPrint  = "cache_fingerprint"
-	keyCachedExecutionID = "cached_execution_id"
-	keyInputs            = "inputs"
-	keyOutputs           = "outputs"
-	keyParentDagID       = "parent_dag_id" // Parent DAG Execution ID.
-	keyIterationIndex    = "iteration_index"
-	keyIterationCount    = "iteration_count"
+	keyDisplayName        = "display_name"
+	keyTaskName           = "task_name"
+	keyImage              = "image"
+	keyPodName            = "pod_name"
+	keyPodUID             = "pod_uid"
+	keyNamespace          = "namespace"
+	keyResourceName       = "resource_name"
+	keyPipelineRoot       = "pipeline_root"
+	keySessionInfoDetails = "bucket_session_info"
+	keyCacheFingerPrint   = "cache_fingerprint"
+	keyCachedExecutionID  = "cached_execution_id"
+	keyInputs             = "inputs"
+	keyOutputs            = "outputs"
+	keyParentDagID        = "parent_dag_id" // Parent DAG Execution ID.
+	keyIterationIndex     = "iteration_index"
+	keyIterationCount     = "iteration_count"
 )
 
 // CreateExecution creates a new MLMD execution under the specified Pipeline.

--- a/backend/src/v2/metadata/client_fake.go
+++ b/backend/src/v2/metadata/client_fake.go
@@ -32,7 +32,7 @@ func NewFakeClient() *FakeClient {
 	return &FakeClient{}
 }
 
-func (c *FakeClient) GetPipeline(ctx context.Context, pipelineName, runID, namespace, runResource, pipelineRoot string) (*Pipeline, error) {
+func (c *FakeClient) GetPipeline(ctx context.Context, pipelineName, runID, namespace, runResource, pipelineRoot string, bucketSessionInfo string) (*Pipeline, error) {
 	return nil, nil
 }
 

--- a/backend/src/v2/metadata/client_test.go
+++ b/backend/src/v2/metadata/client_test.go
@@ -89,7 +89,7 @@ func Test_GetPipeline(t *testing.T) {
 	mlmdClient, err := NewTestMlmdClient()
 	fatalIf(err)
 
-	pipeline, err := client.GetPipeline(ctx, "get-pipeline-test", runId, namespace, runResource, pipelineRoot)
+	pipeline, err := client.GetPipeline(ctx, "get-pipeline-test", runId, namespace, runResource, pipelineRoot, "")
 	fatalIf(err)
 	expectPipelineRoot := fmt.Sprintf("%s/get-pipeline-test/%s", pipelineRoot, runId)
 	if pipeline.GetPipelineRoot() != expectPipelineRoot {
@@ -138,12 +138,12 @@ func Test_GetPipeline_Twice(t *testing.T) {
 	client, err := metadata.NewClient(testMlmdServerAddress, testMlmdServerPort)
 	fatalIf(err)
 
-	pipeline, err := client.GetPipeline(ctx, "get-pipeline-test", runId, namespace, runResource, pipelineRoot)
+	pipeline, err := client.GetPipeline(ctx, "get-pipeline-test", runId, namespace, runResource, pipelineRoot, "")
 	fatalIf(err)
 	// The second call to GetPipeline won't fail because it avoid inserting to MLMD again.
-	samePipeline, err := client.GetPipeline(ctx, "get-pipeline-test", runId, namespace, runResource, pipelineRoot)
+	samePipeline, err := client.GetPipeline(ctx, "get-pipeline-test", runId, namespace, runResource, pipelineRoot, "")
 	fatalIf(err)
-	if (pipeline.GetCtxID() != samePipeline.GetCtxID()) {
+	if pipeline.GetCtxID() != samePipeline.GetCtxID() {
 		t.Errorf("Expect pipeline context ID %d, actual is %d", pipeline.GetCtxID(), samePipeline.GetCtxID())
 	}
 }
@@ -159,7 +159,7 @@ func Test_GetPipelineFromExecution(t *testing.T) {
 	}
 	client := newLocalClientOrFatal(t)
 	ctx := context.Background()
-	pipeline, err := client.GetPipeline(ctx, "get-pipeline-from-execution", newUUIDOrFatal(t), "kubeflow", "workflow/abc", "gs://my-bucket/root")
+	pipeline, err := client.GetPipeline(ctx, "get-pipeline-from-execution", newUUIDOrFatal(t), "kubeflow", "workflow/abc", "gs://my-bucket/root", "")
 	fatalIf(err)
 	execution, err := client.CreateExecution(ctx, pipeline, &metadata.ExecutionConfig{
 		TaskName:      "task1",
@@ -193,7 +193,7 @@ func Test_GetPipelineConcurrently(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := client.GetPipeline(ctx, fmt.Sprintf("get-pipeline-concurrently-test-%s", runIdText), runIdText, namespace, "workflows.argoproj.io/hello-world-"+runIdText, pipelineRoot)
+			_, err := client.GetPipeline(ctx, fmt.Sprintf("get-pipeline-concurrently-test-%s", runIdText), runIdText, namespace, "workflows.argoproj.io/hello-world-"+runIdText, pipelineRoot, "")
 			if err != nil {
 				t.Error(err)
 			}
@@ -205,7 +205,7 @@ func Test_GetPipelineConcurrently(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := client.GetPipeline(ctx, fmt.Sprintf("get-pipeline-concurrently-test-%s", runIdText), runIdText, namespace, "workflows.argoproj.io/hello-world-"+runIdText, pipelineRoot)
+			_, err := client.GetPipeline(ctx, fmt.Sprintf("get-pipeline-concurrently-test-%s", runIdText), runIdText, namespace, "workflows.argoproj.io/hello-world-"+runIdText, pipelineRoot, "")
 			if err != nil {
 				t.Error(err)
 			}
@@ -220,7 +220,7 @@ func Test_DAG(t *testing.T) {
 	client := newLocalClientOrFatal(t)
 	ctx := context.Background()
 	// These parameters do not matter.
-	pipeline, err := client.GetPipeline(ctx, "pipeline-name", newUUIDOrFatal(t), "ns1", "workflow/pipeline-1234", pipelineRoot)
+	pipeline, err := client.GetPipeline(ctx, "pipeline-name", newUUIDOrFatal(t), "ns1", "workflow/pipeline-1234", pipelineRoot, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Resolve [RHOAIENG-1707](https://issues.redhat.com/browse/RHOAIENG-1707) from dsp side

**Description of your changes:**

Adds the ability to specify pipeline root based on prefix within a namespace. This pr allows users to: 

1. provide different credentials for different paths 
2. configure non aws s3 compatible artifact stores 
3. allow tls configuration for artifact store connection
4. adds a new custom property to mlmd `bucket_session_info`, this is added by the root driver container, so we read the kfp-launcher configmap once per pipeline

I would have preferred to organize this very differently but as this is a carried patch I've tried to minimize code deletions to make it easy to merge in upstream changes and minimize conflicts.

**Testing changes** 

Deploy a kfp-launcher configmap that points to your minio/s3/etc: 

<details>

<summary>kfp-launcher-configmap.yaml</summary>

```yaml
apiVersion: v1
data:
  defaultPipelineRoot: s3://my-bucket/v2/artifacts/path/1
  providers: |-
    s3:
      # if non us-east-1, region is required
      endpoint: https://s3.us-east-2.amazonaws.com 
      region: us-east-2
      defaultProviderSecretRef:
        secretName: "secret-1"
        accessKeyKey: "access_key_1"
        secretKeyKey: "secret_key_1"
    minio:
      endpoint: http://minio-dspa.apps.hukhan-3.dev.datahub.redhat.com
      region: minio
      defaultProviderSecretRef:
        secretName: "secret-2"
        accessKeyKey: "access_key_2"
        secretKeyKey: "secret_key_2"
      authConfigs:
        - bucketName: "my-bucket"
          keyPrefix: "v2/artifacts/path/1/"
          secretRef:
            secretName: "secret-3"
            accessKeyKey: "access_key_3"
            secretKeyKey: "secret_key_3"
        - bucketName: "my-bucket"
          keyPrefix: "v2/artifacts/path/2/"
          secretRef:
            secretName: "secret-4"
            accessKeyKey: "access_key_4"
            secretKeyKey: "secret_key_4"
kind: ConfigMap
metadata:
  name: kfp-launcher
  namespace: dspa
```
</details>

Then deploy a dspa in a **non** `kubeflow` namespace: 

<details>

<summary>dspa.yaml </summary> 

```yaml
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
spec:
  dspVersion: v2
  apiServer:
    deploy: true
    image: quay.io/hukhan/ds-pipelines-api-server:pr-4
    argoLauncherImage: quay.io/hukhan/kfp-launcher:pr-4
    argoDriverImage: quay.io/hukhan/kfp-driver:pr-4
  persistenceAgent:
    deploy: true
    image: gcr.io/ml-pipeline/persistenceagent:2.0.2
  scheduledWorkflow:
    deploy: true
    image: gcr.io/ml-pipeline/scheduledworkflow:2.0.2
  mlmd:
    deploy: true
    grpc:
      image: gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0
    envoy:
      image: gcr.io/ml-pipeline/metadata-envoy:2.0.2
  database:
    disableHealthCheck: true
    mariaDB:
      deploy: true
  objectStorage:
    minio:
      deploy: true
      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
  mlpipelineUI:
    image: gcr.io/ml-pipeline/frontend:2.0.2
  workflowController:
    deploy: true
    image: gcr.io/ml-pipeline/workflow-controller:v3.3.10-license-compliance

```

</details>