### PR TITLE
UPSTREAM: <carry>: remove unused images for v2.

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -77,18 +77,10 @@ jobs:
             dockerfile: backend/Dockerfile
           - image: ds-pipelines-frontend
             dockerfile: frontend/Dockerfile
-          - image: ds-pipelines-cacheserver
-            dockerfile: backend/Dockerfile.cacheserver
           - image: ds-pipelines-persistenceagent
             dockerfile: backend/Dockerfile.persistenceagent
           - image: ds-pipelines-scheduledworkflow
             dockerfile: backend/Dockerfile.scheduledworkflow
-          - image: ds-pipelines-viewercontroller
-            dockerfile: backend/Dockerfile.viewercontroller
-          - image: ds-pipelines-artifact-manager
-            dockerfile: backend/artifact_manager/Dockerfile
-          - image: ds-pipelines-metadata-writer
-            dockerfile: backend/metadata_writer/Dockerfile
           - image: ds-pipelines-metadata-grpc
             dockerfile: third_party/ml-metadata/Dockerfile
           - image: ds-pipelines-metadata-envoy

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -23,18 +23,10 @@ jobs:
             dockerfile: backend/Dockerfile
           - image: ds-pipelines-frontend
             dockerfile: frontend/Dockerfile
-          - image: ds-pipelines-cacheserver
-            dockerfile: backend/Dockerfile.cacheserver
           - image: ds-pipelines-persistenceagent
             dockerfile: backend/Dockerfile.persistenceagent
           - image: ds-pipelines-scheduledworkflow
             dockerfile: backend/Dockerfile.scheduledworkflow
-          - image: ds-pipelines-viewercontroller
-            dockerfile: backend/Dockerfile.viewercontroller
-          - image: ds-pipelines-artifact-manager
-            dockerfile: backend/artifact_manager/Dockerfile
-          - image: ds-pipelines-metadata-writer
-            dockerfile: backend/metadata_writer/Dockerfile
           - image: ds-pipelines-metadata-grpc
             dockerfile: third_party/ml-metadata/Dockerfile
           - image: ds-pipelines-metadata-envoy

--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -72,18 +72,10 @@ jobs:
             dockerfile: backend/Dockerfile
           - image: ds-pipelines-frontend
             dockerfile: frontend/Dockerfile
-          - image: ds-pipelines-cacheserver
-            dockerfile: backend/Dockerfile.cacheserver
           - image: ds-pipelines-persistenceagent
             dockerfile: backend/Dockerfile.persistenceagent
           - image: ds-pipelines-scheduledworkflow
             dockerfile: backend/Dockerfile.scheduledworkflow
-          - image: ds-pipelines-viewercontroller
-            dockerfile: backend/Dockerfile.viewercontroller
-          - image: ds-pipelines-artifact-manager
-            dockerfile: backend/artifact_manager/Dockerfile
-          - image: ds-pipelines-metadata-writer
-            dockerfile: backend/metadata_writer/Dockerfile
           - image: ds-pipelines-metadata-grpc
             dockerfile: third_party/ml-metadata/Dockerfile
           - image: ds-pipelines-metadata-envoy
@@ -129,12 +121,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN_PROJECT_EDIT }}
           FULLIMG_API_SERVER: quay.io/${{ env.QUAY_ORG }}/ds-pipelines-api-server:${{ env.TARGET_IMAGE_TAG }}
           FULLIMG_FRONTEND: quay.io/${{ env.QUAY_ORG }}/ds-pipelines-frontend:${{ env.TARGET_IMAGE_TAG }}
-          FULLIMG_CACHESERVER: quay.io/${{ env.QUAY_ORG }}/ds-pipelines-cacheserver:${{ env.TARGET_IMAGE_TAG }}
           FULLIMG_PERSISTENCEAGENT: quay.io/${{ env.QUAY_ORG }}/ds-pipelines-persistenceagent:${{ env.TARGET_IMAGE_TAG }}
           FULLIMG_SCHEDULEDWORKFLOW: quay.io/${{ env.QUAY_ORG }}/ds-pipelines-scheduledworkflow:${{ env.TARGET_IMAGE_TAG }}
-          FULLIMG_VIEWERCONTROLLER: quay.io/${{ env.QUAY_ORG }}/ds-pipelines-viewercontroller:${{ env.TARGET_IMAGE_TAG }}
-          FULLIMG_ARTIFACT_MANAGER: quay.io/${{ env.QUAY_ORG }}/ds-pipelines-artifact-manager:${{ env.TARGET_IMAGE_TAG }}
-          FULLIMG_METADATA_WRITER: quay.io/${{ env.QUAY_ORG }}/ds-pipelines-metadata-writer:${{ env.TARGET_IMAGE_TAG }}
           FULLIMG_METADATA_ENVOY: quay.io/${{ env.QUAY_ORG }}/ds-pipelines-metadata-envoy:${{ env.TARGET_IMAGE_TAG }}
           FULLIMG_METADATA_GRPC: quay.io/${{ env.QUAY_ORG }}/ds-pipelines-metadata-grpc:${{ env.TARGET_IMAGE_TAG }}
           FULLIMG_DRIVER: quay.io/${{ env.QUAY_ORG }}/ds-pipelines-driver:${{ env.TARGET_IMAGE_TAG }}
@@ -160,12 +148,8 @@ jobs:
             **DSP LAUNCHER**: `${{ env.FULLIMG_LAUNCHER }}`
             **Persistence Agent**: `${{ env.FULLIMG_PERSISTENCEAGENT }}`
             **Scheduled Workflow Manager**: `${{ env.FULLIMG_SCHEDULEDWORKFLOW }}`
-            **CRD Viewer Controller**: `${{ env.FULLIMG_VIEWERCONTROLLER }}`
-            **Artifact Manager**: `${{ env.FULLIMG_ARTIFACT_MANAGER }}`
             **MLMD Server**: `${{ env.FULLIMG_METADATA_GRPC }}`
-            **MLMD Writer**: `${{ env.FULLIMG_METADATA_WRITER }}`
             **MLMD Envoy Proxy**: `${{ env.FULLIMG_METADATA_ENVOY }}`
-            **Cache Server**: `${{ env.FULLIMG_CACHESERVER }}`
             **UI**: `${{ env.FULLIMG_FRONTEND }}`
           EOF
 
@@ -184,26 +168,21 @@ jobs:
           metadata:
             name: pr-${{ needs.fetch-data.outputs.pr_number}}
           spec:
+            dspVersion: v2
             apiServer:
               image: "${{ env.FULLIMG_API_SERVER }}"
-              artifactImage: "${{ env.FULLIMG_ARTIFACT_MANAGER }}"
               argoDriverImage: "${{ env.FULLIMG_DRIVER }}"
               argoLauncherImage: "${{ env.FULLIMG_LAUNCHER }}"
             persistenceAgent:
               image: "${{ env.FULLIMG_PERSISTENCEAGENT }}"
             scheduledWorkflow:
               image: "${{ env.FULLIMG_SCHEDULEDWORKFLOW }}"
-            crdViewer:  
-              deploy: true  # Optional component
-              image: "${{ env.FULLIMG_VIEWERCONTROLLER }}"
             mlmd:  
               deploy: true  # Optional component
               grpc:
                 image: "${{ env.FULLIMG_METADATA_GRPC }}"
               envoy:
                 image: "${{ env.FULLIMG_METADATA_ENVOY }}"
-              writer:
-                image: "${{ env.FULLIMG_METADATA_WRITER }}"
             mlpipelineUI:
               deploy: true  # Optional component 
               image: "${{ env.FULLIMG_FRONTEND }}"
@@ -242,14 +221,10 @@ jobs:
         image:
           - ds-pipelines-api-server
           - ds-pipelines-frontend
-          - ds-pipelines-cacheserver
           - ds-pipelines-persistenceagent
           - ds-pipelines-scheduledworkflow
-          - ds-pipelines-viewercontroller
-          - ds-pipelines-artifact-manager
           - ds-pipelines-launcher
           - ds-pipelines-driver
-          - ds-pipelines-metadata-writer
           - ds-pipelines-metadata-grpc
           - ds-pipelines-metadata-envoy
     steps:

--- a/.github/workflows/tag-release-quay.yml
+++ b/.github/workflows/tag-release-quay.yml
@@ -15,12 +15,8 @@ on:
 env:
   IMAGE_SERVER: quay.io/opendatahub/ds-pipelines-api-server
   IMAGE_UI: quay.io/opendatahub/ds-pipelines-frontend
-  IMAGE_CACHE: quay.io/opendatahub/ds-pipelines-cacheserver
   IMAGE_PA: quay.io/opendatahub/ds-pipelines-persistenceagent
   IMAGE_SWF: quay.io/opendatahub/ds-pipelines-scheduledworkflow
-  IMAGE_VC: quay.io/opendatahub/ds-pipelines-viewercontroller
-  IMAGE_ARTIFACT: quay.io/opendatahub/ds-pipelines-artifact-manager
-  IMAGE_MLMD_WRITER: quay.io/opendatahub/ds-pipelines-metadata-writer
   IMAGE_MLMD_ENVOY: quay.io/opendatahub/ds-pipelines-metadata-envoy
   IMAGE_MLMD_GRPC: quay.io/opendatahub/ds-pipelines-metadata-grpc
   IMAGE_LAUNCHER: quay.io/opendatahub/ds-pipelines-launcher
@@ -57,12 +53,8 @@ jobs:
         run: |
           skopeo copy docker://${IMAGE_SERVER}:main-${{ env.HASH }} docker://${IMAGE_SERVER}:${{ env.TAG }}
           skopeo copy docker://${IMAGE_UI}:main-${{ env.HASH }} docker://${IMAGE_UI}:${{ env.TAG }}
-          skopeo copy docker://${IMAGE_CACHE}:main-${{ env.HASH }} docker://${IMAGE_CACHE}:${{ env.TAG }}
           skopeo copy docker://${IMAGE_PA}:main-${{ env.HASH }} docker://${IMAGE_PA}:${{ env.TAG }}
           skopeo copy docker://${IMAGE_SWF}:main-${{ env.HASH }} docker://${IMAGE_SWF}:${{ env.TAG }}
-          skopeo copy docker://${IMAGE_VC}:main-${{ env.HASH }} docker://${IMAGE_VC}:${{ env.TAG }}
-          skopeo copy docker://${IMAGE_ARTIFACT}:main-${{ env.HASH }} docker://${IMAGE_ARTIFACT}:${{ env.TAG }}
-          skopeo copy docker://${IMAGE_MLMD_WRITER}:main-${{ env.HASH }} docker://${IMAGE_MLMD_WRITER}:${{ env.TAG }}
           skopeo copy docker://${IMAGE_MLMD_ENVOY}:main-${{ env.HASH }} docker://${IMAGE_MLMD_ENVOY}:${{ env.TAG }}
           skopeo copy docker://${IMAGE_MLMD_GRPC}:main-${{ env.HASH }} docker://${IMAGE_MLMD_GRPC}:${{ env.TAG }}
           skopeo copy docker://${IMAGE_LAUNCHER}:main-${{ env.HASH }} docker://${IMAGE_LAUNCHER}:${{ env.TAG }}
@@ -74,12 +66,8 @@ jobs:
         run: |
           skopeo copy docker://${IMAGE_SERVER}:main-${{ env.HASH }} docker://${IMAGE_SERVER}:latest
           skopeo copy docker://${IMAGE_UI}:main-${{ env.HASH }} docker://${IMAGE_UI}:latest
-          skopeo copy docker://${IMAGE_CACHE}:main-${{ env.HASH }} docker://${IMAGE_CACHE}:latest
           skopeo copy docker://${IMAGE_PA}:main-${{ env.HASH }} docker://${IMAGE_PA}:latest
           skopeo copy docker://${IMAGE_SWF}:main-${{ env.HASH }} docker://${IMAGE_SWF}:latest
-          skopeo copy docker://${IMAGE_VC}:main-${{ env.HASH }} docker://${IMAGE_VC}:latest
-          skopeo copy docker://${IMAGE_ARTIFACT}:main-${{ env.HASH }} docker://${IMAGE_ARTIFACT}:latest
-          skopeo copy docker://${IMAGE_MLMD_WRITER}:main-${{ env.HASH }} docker://${IMAGE_MLMD_WRITER}:latest
           skopeo copy docker://${IMAGE_MLMD_ENVOY}:main-${{ env.HASH }} docker://${IMAGE_MLMD_ENVOY}:latest
           skopeo copy docker://${IMAGE_MLMD_GRPC}:main-${{ env.HASH }} docker://${IMAGE_MLMD_GRPC}:latest
           skopeo copy docker://${IMAGE_LAUNCHER}:main-${{ env.HASH }} docker://${IMAGE_LAUNCHER}:latest


### PR DESCRIPTION
the following images are not used in dsp v2 argo: 
* viewer controller
* cache server
* metadata writer
* artifact step copy image