### PR TITLE
UPSTREAM: <carry>: feat: expose more filters for runs/jobs

### DIFF
--- a/backend/src/apiserver/model/job.go
+++ b/backend/src/apiserver/model/job.go
@@ -243,6 +243,7 @@ var jobAPIToModelFieldMap = map[string]string{
 	"created_at":          "CreatedAtInSec",
 	"updated_at":          "UpdatedAtInSec",
 	"description":         "Description",
+	"experiment_id":       "ExperimentUUID",    // v2beta1 API
 	"pipeline_name":       "PipelineName",      // v2beta1 API
 	"pipeline_version_id": "PipelineVersionId", // v2beta1 API
 	"pipeline_id":         "PipelineId",        // v2beta1 API

--- a/backend/src/apiserver/model/job.go
+++ b/backend/src/apiserver/model/job.go
@@ -236,13 +236,16 @@ func (j *Job) DefaultSortField() string {
 }
 
 var jobAPIToModelFieldMap = map[string]string{
-	"id":               "UUID",        // v1beta1 API
-	"recurring_run_id": "UUID",        // v2beta1 API
-	"name":             "DisplayName", // v1beta1 API
-	"display_name":     "DisplayName", // v2beta1 API
-	"created_at":       "CreatedAtInSec",
-	"updated_at":       "UpdatedAtInSec",
-	"description":      "Description",
+	"id":                  "UUID",        // v1beta1 API
+	"recurring_run_id":    "UUID",        // v2beta1 API
+	"name":                "DisplayName", // v1beta1 API
+	"display_name":        "DisplayName", // v2beta1 API
+	"created_at":          "CreatedAtInSec",
+	"updated_at":          "UpdatedAtInSec",
+	"description":         "Description",
+	"pipeline_name":       "PipelineName",      // v2beta1 API
+	"pipeline_version_id": "PipelineVersionId", // v2beta1 API
+	"pipeline_id":         "PipelineId",        // v2beta1 API
 }
 
 // APIToModelFieldMap returns a map from API names to field names for model Job.

--- a/backend/src/apiserver/model/run.go
+++ b/backend/src/apiserver/model/run.go
@@ -368,6 +368,7 @@ var runAPIToModelFieldMap = map[string]string{
 	"state_history":       "StateHistory",            // v2beta1 API
 	"runtime_details":     "PipelineRuntimeManifest", // v2beta1 API
 	"recurring_run_id":    "RecurringRunId",          // v2beta1 API
+	"pipeline_name":       "PipelineName",            // v2beta1 API
 	"pipeline_version_id": "PipelineVersionId",       // v2beta1 API
 	"pipeline_id":         "PipelineId",              // v2beta1 API
 }


### PR DESCRIPTION
namely pipeline name, id, and pipeline version id filters for jobs & runs


Testing instructions: 

1. Deploy DSP with the api server that has these changes
2. Create a run, and a recurring run (job/scheduled run/etc.)
3. Either via curl or postman do a GET on the run and job that were created and filter on the added fields (pipeline_id, pipeline_name, pipeline_version_id)


Example: 

![image](https://github.com/opendatahub-io/data-science-pipelines/assets/10904967/a63204d0-f327-40c1-969a-7fbe203107fa)
![image](https://github.com/opendatahub-io/data-science-pipelines/assets/10904967/8834925d-72c5-4697-9953-571135afd3b6)

In the examples above {{dsp-route}} is just the api route you can fetch from ocp console, and don't forget to use the bearer token (gotten via `oc whoami --show-token`)
