### PR TITLE
fix(backend): fixes "cannot save parameter" error message. Fixes #9678 (#10459)

### DIFF
--- a/backend/src/v2/cmd/driver/execution_paths.go
+++ b/backend/src/v2/cmd/driver/execution_paths.go
@@ -1,0 +1,9 @@
+package main
+
+type ExecutionPaths struct {
+	ExecutionID    string
+	IterationCount string
+	CachedDecision string
+	Condition      string
+	PodSpecPatch   string
+}

--- a/backend/src/v2/cmd/driver/main_test.go
+++ b/backend/src/v2/cmd/driver/main_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"github.com/kubeflow/pipelines/backend/src/v2/driver"
+	"os"
+	"testing"
+)
+
+func Test_handleExecutionContainer(t *testing.T) {
+	execution := &driver.Execution{}
+
+	executionPaths := &ExecutionPaths{
+		Condition: "condition.txt",
+	}
+
+	err := handleExecution(execution, CONTAINER, executionPaths)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	verifyFileContent(t, executionPaths.Condition, "nil")
+
+	cleanup(t, executionPaths)
+}
+
+func Test_handleExecutionRootDAG(t *testing.T) {
+	execution := &driver.Execution{}
+
+	executionPaths := &ExecutionPaths{
+		IterationCount: "iteration_count.txt",
+		Condition:      "condition.txt",
+	}
+
+	err := handleExecution(execution, ROOT_DAG, executionPaths)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	verifyFileContent(t, executionPaths.IterationCount, "0")
+	verifyFileContent(t, executionPaths.Condition, "nil")
+
+	cleanup(t, executionPaths)
+}
+
+func cleanup(t *testing.T, executionPaths *ExecutionPaths) {
+	removeIfExists(t, executionPaths.IterationCount)
+	removeIfExists(t, executionPaths.ExecutionID)
+	removeIfExists(t, executionPaths.Condition)
+	removeIfExists(t, executionPaths.PodSpecPatch)
+	removeIfExists(t, executionPaths.CachedDecision)
+}
+
+func removeIfExists(t *testing.T, filePath string) {
+	_, err := os.Stat(filePath)
+	if err == nil {
+		err = os.Remove(filePath)
+		if err != nil {
+			t.Errorf("Unexpected error while removing the created file: %v", err)
+		}
+	}
+}
+
+func verifyFileContent(t *testing.T, filePath string, expectedContent string) {
+	_, err := os.Stat(filePath)
+	if os.IsNotExist(err) {
+		t.Errorf("Expected file %s to be created, but it doesn't exist", filePath)
+	}
+
+	fileContent, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Errorf("Failed to read file contents: %v", err)
+	}
+
+	if string(fileContent) != expectedContent {
+		t.Errorf("Expected file fileContent to be %q, got %q", expectedContent, string(fileContent))
+	}
+}


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/RHOAIENG-1629

Cherry picked from https://github.com/kubeflow/pipelines/pull/10459

### How to test
Deploy and run https://github.com/opendatahub-io/data-science-pipelines-operator/blob/main/config/samples/v2/dspa-simple/dspa_simple.yaml with the `quay.io/opendatahub/ds-pipelines-driver:pr-20` driver image.

```yaml
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
spec:
  dspVersion: v2
  objectStorage:
    minio:
      deploy: true
      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
  mlpipelineUI:
    image: quay.io/opendatahub/ds-pipelines-frontend:latest
  apiServer:
    argoDriverImage: quay.io/opendatahub/ds-pipelines-driver:pr-20
```