### PR TITLE
fix: handle cached input in objstore

### DIFF
--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -77,7 +77,7 @@ func Test_executeV2_Parameters(t *testing.T) {
 			fakeMetadataClient := metadata.NewFakeClient()
 			bucket, err := blob.OpenBucket(context.Background(), "gs://test-bucket")
 			assert.Nil(t, err)
-			bucketConfig, err := objectstore.ParseBucketConfig("gs://test-bucket/pipeline-root/")
+			bucketConfig, err := objectstore.ParseBucketConfig("gs://test-bucket/pipeline-root/", nil)
 			assert.Nil(t, err)
 			_, _, err = executeV2(context.Background(), test.executorInput, addNumbersComponent, "sh", test.executorArgs, bucket, bucketConfig, fakeMetadataClient, "namespace", fakeKubernetesClientset)
 

--- a/backend/src/v2/config/env.go
+++ b/backend/src/v2/config/env.go
@@ -125,7 +125,7 @@ type SecretRef struct {
 
 func (c *Config) GetBucketSessionInfo() (objectstore.SessionInfo, error) {
 	path := c.DefaultPipelineRoot()
-	bucketConfig, err := objectstore.ParseBucketConfig(path)
+	bucketConfig, err := objectstore.ParseBucketPathToConfig(path)
 	if err != nil {
 		return objectstore.SessionInfo{}, err
 	}

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -124,7 +124,7 @@ func Test_parseCloudBucket(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := objectstore.ParseBucketConfig(tt.path)
+			got, err := objectstore.ParseBucketConfig(tt.path, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%q: parseCloudBucket() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 				return


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHOAIENG-4450

# Description

This problem occurs when an executor tries to pull a cached image generated from another run. This error happens because, previously of the way the logic distinguished between "defaultBucket" and "nonDefaultBucket". The way to distinguish was based on path prefixes, for instance if  artifact is generated in run with id `runid1` it's stored in   `s3://bucket/runid1/artifact.txt`. If the run with id `runid2` wants to use "artifact.txt", it will expect it in  `s3://bucket/runid2/artifact.txt`, but looking at the metadata for artifact `artifact.txt` if will see that the prefix is different (i.e: `s3://bucket/runid1`), so it will ignore the default bucket, and regenerate the bucket config based on the new s3 path. 

In our carried patch [here](https://github.com/opendatahub-io/data-science-pipelines/pull/4), we changed the regeneration logic. Previously, when the bucket config was regenerated, it would either: (1) rely on the default minio, or (2) rely on the user to provide in their pipeline env the obj store config.

Since we now rely on kfp-launcher config for obj store data, we removed this regeneration logic. So in this pr when evaluating if the artifact is cached, we now check whether the expected bucket is the same with a different path (i.e. `runid1` vs `runid2`, if so, we re-use our default bucket's config that we fetched earlier from the driver. 

# Testing instruction 

First reproduce the issue, instructions [here](https://issues.redhat.com/browse/RHOAIENG-4450). 

Then deploy the new changeset, only the kfp-launcher has changed, so you could just update that image if you wish. 

You should start with a fresh dspa, re-run the same pipeline twice, you should see the same error this time, instead of differing errors. 

Also confirm other pipelines with data passing still work, to ensure no regression is introduced.
