### PR TITLE
UPSTREAM: <carry>: chore: add meaningful logs to client initialization.

### DIFF
--- a/backend/src/apiserver/client_manager/client_manager.go
+++ b/backend/src/apiserver/client_manager/client_manager.go
@@ -168,9 +168,10 @@ func (c *ClientManager) Authenticators() []auth.Authenticator {
 
 func (c *ClientManager) init() {
 	glog.Info("Initializing client manager")
+	glog.Info("Initializing DB client...")
 	db := InitDBClient(common.GetDurationConfig(initConnectionTimeout))
 	db.SetConnMaxLifetime(common.GetDurationConfig(dbConMaxLifeTime))
-
+	glog.Info("DB client initialized successfully")
 	// time
 	c.time = util.NewRealTime()
 
@@ -185,8 +186,9 @@ func (c *ClientManager) init() {
 	c.resourceReferenceStore = storage.NewResourceReferenceStore(db)
 	c.dBStatusStore = storage.NewDBStatusStore(db)
 	c.defaultExperimentStore = storage.NewDefaultExperimentStore(db)
+	glog.Info("Initializing Minio client...")
 	c.objectStore = initMinioClient(common.GetDurationConfig(initConnectionTimeout))
-
+	glog.Info("Minio client initialized successfully")
 	// Use default value of client QPS (5) & burst (10) defined in
 	// k8s.io/client-go/rest/config.go#RESTClientFor
 	clientParams := util.ClientParameters{


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHOAIENG-3970

**Description of your changes:**
It is annoying when users see a "Initializing client manager" log and it's just stuck, not knowing whether db or minio connection failed, these simple logs will go a long way in helping troubleshoot such issues.

## testing instructions

1. deploy dspa
2. check pipeline server logs, and see whether new logs show up in the changes 
