### PR TITLE
UPSTREAM: <carry>: feat: mount EmptyDir volumes for launcher write locations pt 2

### DIFF
--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -42,6 +42,8 @@ const (
 	dotLocalScratchName     = "dot-local-scratch"
 	dotCacheScratchLocation = "/.cache"
 	dotCacheScratchName     = "dot-cache-scratch"
+	dotConfigScratchLocation = "/.config"
+	dotConfigScratchName     = "dot-config-scratch"
 )
 
 func (c *workflowCompiler) Container(name string, component *pipelinespec.ComponentSpec, container *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec) error {
@@ -289,6 +291,12 @@ func (c *workflowCompiler) addContainerExecutorTemplate() string {
 					EmptyDir: &k8score.EmptyDirVolumeSource{},
 				},
 			},
+			{
+				Name: dotConfigScratchName,
+				VolumeSource: k8score.VolumeSource{
+					EmptyDir: &k8score.EmptyDirVolumeSource{},
+				},
+			},
 		},
 		InitContainers: []wfapi.UserContainer{{
 			Container: k8score.Container{
@@ -337,6 +345,10 @@ func (c *workflowCompiler) addContainerExecutorTemplate() string {
 				{
 					Name:      dotCacheScratchName,
 					MountPath: dotCacheScratchLocation,
+				},
+				{
+					Name:      dotConfigScratchName,
+					MountPath: dotConfigScratchLocation,
 				},
 			},
 			EnvFrom: []k8score.EnvFromSource{metadataEnvFrom},

--- a/backend/src/v2/compiler/argocompiler/testdata/create_mount_delete_dynamic_pvc.yaml
+++ b/backend/src/v2/compiler/argocompiler/testdata/create_mount_delete_dynamic_pvc.yaml
@@ -152,6 +152,8 @@ spec:
         name: dot-local-scratch
       - mountPath: /.cache
         name: dot-cache-scratch
+      - mountPath: /.config
+        name: dot-config-scratch
     initContainers:
     - command:
       - launcher-v2
@@ -188,6 +190,8 @@ spec:
       name: dot-local-scratch
     - emptyDir: { }
       name: dot-cache-scratch
+    - emptyDir: { }
+      name: dot-config-scratch
   - dag:
       tasks:
       - arguments:

--- a/backend/src/v2/compiler/argocompiler/testdata/hello_world.yaml
+++ b/backend/src/v2/compiler/argocompiler/testdata/hello_world.yaml
@@ -135,6 +135,8 @@ spec:
         name: dot-local-scratch
       - mountPath: /.cache
         name: dot-cache-scratch
+      - mountPath: /.config
+        name: dot-config-scratch
     initContainers:
     - command:
       - launcher-v2
@@ -171,6 +173,8 @@ spec:
       name: dot-local-scratch
     - emptyDir: {}
       name: dot-cache-scratch
+    - emptyDir: {}
+      name: dot-config-scratch
   - dag:
       tasks:
       - arguments:


### PR DESCRIPTION
follows up on dfe6edc, which does an EmptyDir mount for /.local and /.cache. /.config is another common write location, so EmptyDir mount that too.

To test, verify that this pipeline now works:
https://github.com/kubeflow/pipelines/blob/master/samples/v2/producer_consumer_param.py


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->

