### PR TITLE
UPSTREAM: <carry>: Fix for default Pipelineroot failures

### DIFF
--- a/backend/src/v2/config/env.go
+++ b/backend/src/v2/config/env.go
@@ -19,10 +19,11 @@ package config
 import (
 	"context"
 	"fmt"
-	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 	"io/ioutil"
-	"sigs.k8s.io/yaml"
 	"strings"
+
+	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
+	"sigs.k8s.io/yaml"
 
 	"github.com/golang/glog"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
@@ -123,8 +124,7 @@ type SecretRef struct {
 	SecretKeyKey string `json:"secretKeyKey"`
 }
 
-func (c *Config) GetBucketSessionInfo() (objectstore.SessionInfo, error) {
-	path := c.DefaultPipelineRoot()
+func (c *Config) GetBucketSessionInfo(path string) (objectstore.SessionInfo, error) {
 	bucketConfig, err := objectstore.ParseBucketPathToConfig(path)
 	if err != nil {
 		return objectstore.SessionInfo{}, err

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
-
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/uuid"
@@ -34,6 +32,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/v2/config"
 	"github.com/kubeflow/pipelines/backend/src/v2/expression"
 	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
+	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
 	pb "github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -134,28 +133,30 @@ func RootDAG(ctx context.Context, opts Options, mlmd *metadata.Client) (executio
 	}
 	// TODO(v2): in pipeline spec, rename GCS output directory to pipeline root.
 	pipelineRoot := opts.RuntimeConfig.GetGcsOutputDirectory()
+
+	restConfig, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize kubernetes client: %w", err)
+	}
+	k8sClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize kubernetes client set: %w", err)
+	}
+	cfg, err := config.FromConfigMap(ctx, k8sClient, opts.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
 	pipelineBucketSessionInfo := objectstore.SessionInfo{}
 	if pipelineRoot != "" {
 		glog.Infof("PipelineRoot=%q", pipelineRoot)
 	} else {
-		restConfig, err := rest.InClusterConfig()
-		if err != nil {
-			return nil, fmt.Errorf("failed to initialize kubernetes client: %w", err)
-		}
-		k8sClient, err := kubernetes.NewForConfig(restConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to initialize kubernetes client set: %w", err)
-		}
-		cfg, err := config.FromConfigMap(ctx, k8sClient, opts.Namespace)
-		if err != nil {
-			return nil, err
-		}
 		pipelineRoot = cfg.DefaultPipelineRoot()
 		glog.Infof("PipelineRoot=%q from default config", pipelineRoot)
-		pipelineBucketSessionInfo, err = cfg.GetBucketSessionInfo()
-		if err != nil {
-			return nil, err
-		}
+	}
+	pipelineBucketSessionInfo, err = cfg.GetBucketSessionInfo(pipelineRoot)
+	if err != nil {
+		return nil, err
 	}
 	bucketSessionInfo, err := json.Marshal(pipelineBucketSessionInfo)
 	if err != nil {


### PR DESCRIPTION
**Description of your changes:**
 Resolves [RHOAIENG-7209](https://issues.redhat.com/browse/RHOAIENG-7209)

Fixed the issue with fetching the kfp-launcher default config when the provided pipelineroot is set via SDK or UI.

Testing instructions:

- Deploy dspa using the  dspa.pr-51.yaml in this PR.
-  While creating a pipeline run in the UI, provide the custom pipeline root in the parameters and the run should complete successfully.
-  Create another run without custom pipeline root and it should complete successfully.

**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
