### PR TITLE
UPSTREAM: <carry>: remove uneed image builds.

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -81,10 +81,6 @@ jobs:
             dockerfile: backend/Dockerfile.persistenceagent
           - image: ds-pipelines-scheduledworkflow
             dockerfile: backend/Dockerfile.scheduledworkflow
-          - image: ds-pipelines-metadata-grpc
-            dockerfile: third_party/ml-metadata/Dockerfile
-          - image: ds-pipelines-metadata-envoy
-            dockerfile: third_party/metadata_envoy/Dockerfile
           - image: ds-pipelines-driver
             dockerfile: backend/Dockerfile.driver
           - image: ds-pipelines-launcher


### PR DESCRIPTION
MLMD GRPC and Envoy image builds are no longer needed since we
leveragage service mesh and MR's images respectively.
