### PR TITLE
UPSTREAM: <carry>: use asc artifact ordering by default.

### DIFF
--- a/backend/api/v2beta1/artifacts.proto
+++ b/backend/api/v2beta1/artifacts.proto
@@ -87,7 +87,7 @@ message ListArtifactRequest {
 
   // Optional. Ordering field. [default = ID]
   Field order_by_field = 2;
-  // Optional. Can be either "asc" (ascending) or "dsc" (descending). [default = asc]
+  // Optional. Can be either "asc" (ascending) or "desc" (descending). [default = asc]
   string order_by = 3;
 
   // Optional. The next_page_token value returned from a previous List request, if any.

--- a/backend/api/v2beta1/go_client/artifacts.pb.go
+++ b/backend/api/v2beta1/go_client/artifacts.pb.go
@@ -225,7 +225,7 @@ type ListArtifactRequest struct {
 	MaxResultSize int32 `protobuf:"varint,1,opt,name=max_result_size,json=maxResultSize,proto3" json:"max_result_size,omitempty"`
 	// Optional. Ordering field. [default = ID]
 	OrderByField ListArtifactRequest_Field `protobuf:"varint,2,opt,name=order_by_field,json=orderByField,proto3,enum=kubeflow.pipelines.backend.api.v2beta1.ListArtifactRequest_Field" json:"order_by_field,omitempty"`
-	// Optional. Can be either "asc" (ascending) or "dsc" (descending). [default = asc]
+	// Optional. Can be either "asc" (ascending) or "desc" (descending). [default = asc]
 	OrderBy string `protobuf:"bytes,3,opt,name=order_by,json=orderBy,proto3" json:"order_by,omitempty"`
 	// Optional. The next_page_token value returned from a previous List request, if any.
 	NextPageToken string `protobuf:"bytes,4,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`

--- a/backend/api/v2beta1/swagger/artifacts.swagger.json
+++ b/backend/api/v2beta1/swagger/artifacts.swagger.json
@@ -52,7 +52,7 @@
           },
           {
             "name": "order_by",
-            "description": "Optional. Can be either \"asc\" (ascending) or \"dsc\" (descending). [default = asc].",
+            "description": "Optional. Can be either \"asc\" (ascending) or \"desc\" (descending). [default = asc].",
             "in": "query",
             "required": false,
             "type": "string"

--- a/backend/api/v2beta1/swagger/kfp_api_single_file.swagger.json
+++ b/backend/api/v2beta1/swagger/kfp_api_single_file.swagger.json
@@ -62,7 +62,7 @@
           },
           {
             "name": "order_by",
-            "description": "Optional. Can be either \"asc\" (ascending) or \"dsc\" (descending). [default = asc].",
+            "description": "Optional. Can be either \"asc\" (ascending) or \"desc\" (descending). [default = asc].",
             "in": "query",
             "required": false,
             "type": "string"

--- a/backend/src/apiserver/server/artifact_server.go
+++ b/backend/src/apiserver/server/artifact_server.go
@@ -82,13 +82,8 @@ func (s *ArtifactServer) ListArtifacts(ctx context.Context, r *apiv2beta1.ListAr
 	orderByField := r.OrderByField.String()
 
 	orderByAsc := true
-	switch r.OrderBy {
-	case "asc":
-		orderByAsc = true
-	case "dsc":
+	if r.OrderBy == "desc" {
 		orderByAsc = false
-	default:
-		return nil, util.Wrap(err, "Invalid value for order_by, valid values are 'asc' or 'dsc'.")
 	}
 
 	maxResultSize := r.MaxResultSize

--- a/backend/src/apiserver/server/artifact_server_test.go
+++ b/backend/src/apiserver/server/artifact_server_test.go
@@ -190,7 +190,7 @@ func TestListArtifacts(t *testing.T) {
 			artifactRequest: &apiv2beta1.ListArtifactRequest{
 				MaxResultSize: 2,
 				Namespace:     "test-namespace",
-				OrderBy:       "dsc",
+				OrderBy:       "desc",
 			},
 			expectedArtifacts: []*apiv2beta1.Artifact{artifact1, artifact0},
 			wantErr:           false,
@@ -200,7 +200,7 @@ func TestListArtifacts(t *testing.T) {
 			artifactRequest: &apiv2beta1.ListArtifactRequest{
 				MaxResultSize: 2,
 				Namespace:     "",
-				OrderBy:       "dsc",
+				OrderBy:       "desc",
 			},
 			expectedArtifacts: []*apiv2beta1.Artifact{artifact1, artifact0},
 			wantErr:           true,


### PR DESCRIPTION
We should set order_by to asc by default.