### PR TITLE
UPSTREAM: <carry>: Reworded logs to indicate non-critical issues and …

### DIFF
--- a/backend/src/apiserver/client/swf.go
+++ b/backend/src/apiserver/client/swf.go
@@ -61,7 +61,6 @@ func NewScheduledWorkflowClientOrFatal(initConnectionTimeout time.Duration, clie
 	if err == nil {
 		return swfClientInstance
 	}
-	glog.Infof("(Expected when in cluster) Failed to create scheduled workflow client by out of cluster kubeconfig. Error: %v", err)
 
 	glog.Infof("Starting to create scheduled workflow client by in cluster config.")
 	b := backoff.NewExponentialBackOff()

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -20,8 +20,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
-	"google.golang.org/grpc/credentials"
 	"io"
 	"io/ioutil"
 	"math"
@@ -31,6 +29,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/golang/glog"
@@ -98,13 +99,13 @@ func main() {
 	)
 	err = loadSamples(resourceManager)
 	if err != nil {
-		glog.Fatalf("Failed to load samples. Err: %v", err)
+		glog.Infof("Couldn't load optional pipeline samples: %v", err)
 	}
 
 	if !common.IsMultiUserMode() {
 		_, err = resourceManager.CreateDefaultExperiment("")
 		if err != nil {
-			glog.Fatalf("Failed to create default experiment. Err: %v", err)
+			glog.Infof("Couldn't create optional default experiment: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Resolves [RHOAIENG-6710](https://issues.redhat.com/browse/RHOAIENG-6710)

Updated some log messages in DSP server to clearly convey that the reported issues are non-critical and intended for informational purposes only, helping users understand that these messages do not require immediate action.