### PR TITLE
WIP: fix(backend): add retries to getOrInsertContext in MLMD client

### DIFF
--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -1131,6 +1131,28 @@ func (c *Client) getContextTypeID(ctx context.Context, contextType *pb.ContextTy
 func (c *Client) getOrInsertContext(ctx context.Context, name string, contextType *pb.ContextType, customProps map[string]*pb.Value) (*pb.Context, error) {
 	fmt.Printf("getOrInsertContext: name=%q, type=%q\n", name, contextType.GetName())
 
+	marshaler := protojson.MarshalOptions{
+		Multiline: true,
+		Indent:    "  ",
+	}
+
+	jsonStr, err := marshaler.Marshal(contextType)
+	if err != nil {
+		fmt.Printf("Failed to marshal: %v", err)
+	}
+
+	fmt.Println("contextType:")
+	fmt.Println(string(jsonStr))
+
+	fmt.Println("customProps:")
+	for key, value := range customProps {
+		jsonStr, err := marshaler.Marshal(value)
+		if err != nil {
+			fmt.Printf("Failed to marshal key %s: %v", key, err)
+		}
+		fmt.Printf("Key: %s, Value: %s\n", key, string(jsonStr))
+	}
+
 	// This function is known to be flaky and racy right after a server is initially created
 	// and pipeline runs are just starting, so we retry up to 3 times. The actual cause of the
 	// race isn't fully understood, but it's probably caused by deadlocks in MLMD SQL code.


### PR DESCRIPTION
**Description of your changes:**

Add retries to getOrInsertContext in MLMD client.

This function is known to be flaky and racy right after a server is initially created and pipeline runs are just starting, so we retry up to 3 times. The actual cause of the race isn't fully understood, but it's probably caused by deadlocks in MLMD SQL code. General MySQL advice is to retry on deadlock errors.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
