### PR TITLE
UPSTREAM: 10268: fix: get pipeline by name is broken due to version typo

### DIFF
--- a/backend/src/apiserver/server/pipeline_server.go
+++ b/backend/src/apiserver/server/pipeline_server.go
@@ -314,7 +314,7 @@ func (s *PipelineServer) getPipelineByName(ctx context.Context, name string, nam
 	switch apiRequestVersion {
 	case "v1beta1":
 		return s.resourceManager.GetPipelineByNameAndNamespaceV1(name, namespace)
-	case "V2beta1":
+	case "v2beta1":
 		p, err := s.resourceManager.GetPipelineByNameAndNamespace(name, namespace)
 		return p, nil, err
 	default:


### PR DESCRIPTION
**Description of your changes:**
function getPipelineByName have a version typo:
V1beta1 -> v1beta1

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
