### PR TITLE
UPSTREAM: <carry>: Bumped actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build-prs-trigger.yaml
+++ b/.github/workflows/build-prs-trigger.yaml
@@ -27,7 +27,7 @@ jobs:
           echo ${{ github.event.pull_request.state }} >> ./pr/pr_state
           echo ${{ github.event.pull_request.head.sha }} >> ./pr/head_sha
           echo ${{ github.event.action }} >> ./pr/event_action
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/


### PR DESCRIPTION
This PR updates `upload-artifact` action due to deprecation. The current version [is blocking PRs](https://github.com/opendatahub-io/data-science-pipelines/actions/runs/11001948742/job/30547796151?pr=72).
Deprecation notice: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
