### PR TITLE
UPSTREAM: <carry>: Fixed importer component when podToPodTLS is true

### DIFF
--- a/backend/src/v2/compiler/argocompiler/importer.go
+++ b/backend/src/v2/compiler/argocompiler/importer.go
@@ -17,6 +17,7 @@ package argocompiler
 import (
 	"fmt"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"strconv"
 
 	wfapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
@@ -79,6 +80,7 @@ func (c *workflowCompiler) addImporterTemplate() string {
 		fmt.Sprintf("$(%s)", component.EnvPodUID),
 		"--mlmd_server_address", common.GetMetadataGrpcServiceServiceHost(),
 		"--mlmd_server_port", common.GetMetadataGrpcServiceServicePort(),
+		"--metadataTLSEnabled", strconv.FormatBool(common.GetMetadataTLSEnabled()),
 	}
 	importerTemplate := &wfapi.Template{
 		Name: name,

--- a/backend/src/v2/compiler/argocompiler/testdata/importer.yaml
+++ b/backend/src/v2/compiler/argocompiler/testdata/importer.yaml
@@ -41,6 +41,8 @@ spec:
       - "metadata-grpc-service"
       - --mlmd_server_port
       - "8080"
+      - --metadataTLSEnabled
+      - "false"
       command:
       - launcher-v2
       env:

--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -120,7 +120,9 @@ func NewClient(serverAddress, serverPort string, tlsEnabled bool) (*Client, erro
 
 	creds := insecure.NewCredentials()
 	if tlsEnabled {
-		config := &tls.Config{}
+		config := &tls.Config{
+			InsecureSkipVerify: true, // This should be removed by https://issues.redhat.com/browse/RHOAIENG-13871
+		}
 		creds = credentials.NewTLS(config)
 	}
 


### PR DESCRIPTION
**Description of your changes:**
Resolves: https://issues.redhat.com/browse/RHOAIENG-13327

**How to test it:**

1. Deploy the following DSPA using the images built in this PR

```yaml
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
spec:
  dspVersion: v2
  podToPodTLS: true
  apiServer:
    enableSamplePipeline: true
    image: quay.io/opendatahub/ds-pipelines-api-server:pr-91
    argoLauncherImage: quay.io/opendatahub/ds-pipelines-launcher:pr-91
    argoDriverImage: quay.io/opendatahub/ds-pipelines-driver:pr-91
    cABundle:
      configMapKey: ca.crt
      configMapName: kube-root-ca.crt
  objectStorage:
    enableExternalRoute: true
    minio:
      deploy: true
      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
  mlpipelineUI:
    image: quay.io/opendatahub/ds-pipelines-frontend:latest
```

2. Import the following pipeline

```yaml
# PIPELINE DEFINITION
# Name: my-pipe
# Inputs:
#    artifact_uri: str
#    standard_scaler: bool [Default: True]
components:
  comp-importer:
    executorLabel: exec-importer
    inputDefinitions:
      parameters:
        uri:
          parameterType: STRING
    outputDefinitions:
      artifacts:
        artifact:
          artifactType:
            schemaTitle: system.Dataset
            schemaVersion: 0.0.1
  comp-normalize-dataset:
    executorLabel: exec-normalize-dataset
    inputDefinitions:
      artifacts:
        input_iris_dataset:
          artifactType:
            schemaTitle: system.Dataset
            schemaVersion: 0.0.1
      parameters:
        standard_scaler:
          parameterType: BOOLEAN
    outputDefinitions:
      artifacts:
        normalized_iris_dataset:
          artifactType:
            schemaTitle: system.Dataset
            schemaVersion: 0.0.1
deploymentSpec:
  executors:
    exec-importer:
      importer:
        artifactUri:
          runtimeParameter: uri
        reimport: true
        typeSchema:
          schemaTitle: system.Dataset
          schemaVersion: 0.0.1
    exec-normalize-dataset:
      container:
        args:
        - --executor_input
        - '{{$}}'
        - --function_to_execute
        - normalize_dataset
        command:
        - sh
        - -c
        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
          \  python3 -m pip install --quiet --no-warn-script-location 'pandas==2.2.0'\
          \ 'scikit-learn==1.4.0' && \"$0\" \"$@\"\n"
        - sh
        - -ec
        - 'program_path=$(mktemp -d)


          printf "%s" "$0" > "$program_path/ephemeral_component.py"

          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"

          '
        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
          \ *\n\ndef normalize_dataset(\n    input_iris_dataset: Input[Dataset], normalized_iris_dataset:\
          \ Output[Dataset], standard_scaler: bool\n):\n    import pandas as pd  #\
          \ noqa: PLC0415\n    from sklearn.preprocessing import MinMaxScaler, StandardScaler\
          \  # noqa: PLC0415\n\n    with open(input_iris_dataset.path) as f:\n   \
          \     df = pd.read_csv(f)\n    labels = df.pop(\"Labels\")\n\n    scaler\
          \ = StandardScaler() if standard_scaler else MinMaxScaler()\n\n    df =\
          \ pd.DataFrame(scaler.fit_transform(df))\n    df[\"Labels\"] = labels\n\
          \    normalized_iris_dataset.metadata[\"state\"] = \"Normalized\"\n    with\
          \ open(normalized_iris_dataset.path, \"w\") as f:\n        df.to_csv(f)\n\
          \n"
        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
pipelineInfo:
  name: my-pipe
root:
  dag:
    tasks:
      importer:
        cachingOptions: {}
        componentRef:
          name: comp-importer
        inputs:
          parameters:
            uri:
              componentInputParameter: artifact_uri
        taskInfo:
          name: importer
      normalize-dataset:
        cachingOptions: {}
        componentRef:
          name: comp-normalize-dataset
        dependentTasks:
        - importer
        inputs:
          artifacts:
            input_iris_dataset:
              taskOutputArtifact:
                outputArtifactKey: artifact
                producerTask: importer
          parameters:
            standard_scaler:
              componentInputParameter: standard_scaler
        taskInfo:
          name: normalize-dataset
  inputDefinitions:
    parameters:
      artifact_uri:
        parameterType: STRING
      standard_scaler:
        defaultValue: true
        isOptional: true
        parameterType: BOOLEAN
schemaVersion: 2.1.0
sdkVersion: kfp-2.9.0
```

3. Create a run of the `[Demo] iris-training` pipeline
4. When the pipeline run is completed, go to Artifacts and click the `iris_dataset` artifact
    <img width="767" alt="Screenshot 2024-10-23 at 15 30 55" src="https://github.com/user-attachments/assets/2b21d852-2cb3-4f68-be5f-26f65050cc8b">
5. Copy the URI
    ![image](https://github.com/user-attachments/assets/5e86413e-c3ff-4367-89ce-75b2aac666b4)
6. Create a run of the pipeline you imported in step 2 using the URI you copied on step 5
7. The pipeline should be completed successfully.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
