### PR TITLE
feat(sdk/backend): Add support for placeholders in resource limits

### DIFF
--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -368,6 +368,35 @@ func Container(ctx context.Context, opts Options, mlmd *metadata.Client, cacheCl
 	return execution, nil
 }
 
+// getPodResource will accept the new field that accepts placeholders (e.g. resourceMemoryLimit) and the old float64
+// field (e.g. memoryLimit) and return the resolved value as a Quantity. If the returned Quantity is nil, it was not set
+// by the user. If the new field is set, the old field is ignored.
+func getPodResource(
+	new string, old float64, executorInput *pipelinespec.ExecutorInput, oldFmtStr string,
+) (*k8sres.Quantity, error) {
+	var resolved string
+
+	if new != "" {
+		var err error
+
+		resolved, err = resolvePodSpecInputRuntimeParameter(new, executorInput)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve executor input when retrieving pod resource: %w", err)
+		}
+	} else if old != 0 {
+		resolved = fmt.Sprintf(oldFmtStr, old)
+	} else {
+		return nil, nil
+	}
+
+	q, err := k8sres.ParseQuantity(resolved)
+	if err != nil {
+		return nil, err
+	}
+
+	return &q, nil
+}
+
 // initPodSpecPatch generates a strategic merge patch for pod spec, it is merged
 // to container base template generated in compiler/container.go. Therefore, only
 // dynamic values are patched here. The volume mounts / configmap mounts are
@@ -430,42 +459,85 @@ func initPodSpecPatch(
 		Limits:   map[k8score.ResourceName]k8sres.Quantity{},
 		Requests: map[k8score.ResourceName]k8sres.Quantity{},
 	}
-	memoryLimit := container.GetResources().GetMemoryLimit()
-	if memoryLimit != 0 {
-		q, err := k8sres.ParseQuantity(fmt.Sprintf("%vG", memoryLimit))
-		if err != nil {
-			return nil, fmt.Errorf("failed to init podSpecPatch: %w", err)
-		}
-		res.Limits[k8score.ResourceMemory] = q
+
+	memoryLimit, err := getPodResource(
+		container.GetResources().GetResourceMemoryLimit(),
+		container.GetResources().GetMemoryLimit(),
+		executorInput,
+		"%vG",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init podSpecPatch: %w", err)
 	}
-	memoryRequest := container.GetResources().GetMemoryRequest()
-	if memoryRequest != 0 {
-		q, err := k8sres.ParseQuantity(fmt.Sprintf("%vG", memoryRequest))
-		if err != nil {
-			return nil, err
-		}
-		res.Requests[k8score.ResourceMemory] = q
+	if memoryLimit != nil {
+		res.Limits[k8score.ResourceMemory] = *memoryLimit
 	}
-	cpuLimit := container.GetResources().GetCpuLimit()
-	if cpuLimit != 0 {
-		q, err := k8sres.ParseQuantity(fmt.Sprintf("%v", cpuLimit))
-		if err != nil {
-			return nil, fmt.Errorf("failed to init podSpecPatch: %w", err)
-		}
-		res.Limits[k8score.ResourceCPU] = q
+
+	memoryRequest, err := getPodResource(
+		container.GetResources().GetResourceMemoryRequest(),
+		container.GetResources().GetMemoryRequest(),
+		executorInput,
+		"%vG",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init podSpecPatch: %w", err)
 	}
-	cpuRequest := container.GetResources().GetCpuRequest()
-	if cpuRequest != 0 {
-		q, err := k8sres.ParseQuantity(fmt.Sprintf("%v", cpuRequest))
-		if err != nil {
-			return nil, err
-		}
-		res.Requests[k8score.ResourceCPU] = q
+	if memoryRequest != nil {
+		res.Requests[k8score.ResourceMemory] = *memoryRequest
+	}
+
+	cpuLimit, err := getPodResource(
+		container.GetResources().GetResourceCpuLimit(),
+		container.GetResources().GetCpuLimit(),
+		executorInput,
+		"%v",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init podSpecPatch: %w", err)
+	}
+	if cpuLimit != nil {
+		res.Limits[k8score.ResourceCPU] = *cpuLimit
+	}
+
+	cpuRequest, err := getPodResource(
+		container.GetResources().GetResourceCpuRequest(),
+		container.GetResources().GetCpuRequest(),
+		executorInput,
+		"%v",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init podSpecPatch: %w", err)
+	}
+	if cpuRequest != nil {
+		res.Requests[k8score.ResourceCPU] = *cpuRequest
 	}
 	accelerator := container.GetResources().GetAccelerator()
 	if accelerator != nil {
-		if accelerator.GetType() != "" && accelerator.GetCount() > 0 {
-			q, err := k8sres.ParseQuantity(fmt.Sprintf("%v", accelerator.GetCount()))
+		var acceleratorType string
+		if accelerator.GetResourceType() != "" {
+			acceleratorType, err = resolvePodSpecInputRuntimeParameter(accelerator.GetResourceType(), executorInput)
+			if err != nil {
+				return nil, fmt.Errorf("failed to init podSpecPatch: %w", err)
+			}
+		} else if accelerator.GetType() != "" {
+			acceleratorType = accelerator.GetType()
+		}
+
+		var acceleratorCount string
+
+		if accelerator.GetResourceCount() != "" {
+			var err error
+
+			acceleratorCount, err = resolvePodSpecInputRuntimeParameter(accelerator.GetResourceCount(), executorInput)
+			if err != nil {
+				return nil, fmt.Errorf("failed to init podSpecPatch: %w", err)
+			}
+		} else if accelerator.Count > 0 {
+			acceleratorCount = fmt.Sprintf("%v", accelerator.GetCount())
+		}
+
+		if acceleratorType != "" && acceleratorCount != "" {
+			q, err := k8sres.ParseQuantity(acceleratorCount)
 			if err != nil {
 				return nil, fmt.Errorf("failed to init podSpecPatch: %w", err)
 			}
@@ -1111,6 +1183,8 @@ func resolveInputs(ctx context.Context, dag *metadata.DAG, iterationIndex *int, 
 		return tasks, nil
 	}
 	for name, paramSpec := range task.GetInputs().GetParameters() {
+		glog.V(4).Infof("name: %v", name)
+		glog.V(4).Infof("paramSpec: %v", paramSpec)
 		paramError := func(err error) error {
 			return fmt.Errorf("resolving input parameter %s with spec %s: %w", name, paramSpec, err)
 		}

--- a/backend/third_party_licenses/apiserver.csv
+++ b/backend/third_party_licenses/apiserver.csv
@@ -83,7 +83,7 @@ github.com/klauspost/pgzip,https://github.com/klauspost/pgzip/blob/v1.2.6/LICENS
 github.com/kubeflow/kfp-tekton/tekton-catalog/pipeline-loops/pkg/apis/pipelineloop,https://github.com/kubeflow/kfp-tekton/blob/a75d4b3711ff/tekton-catalog/pipeline-loops/LICENSE,Apache-2.0
 github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-exithandler/pkg/apis/exithandler,https://github.com/kubeflow/kfp-tekton/blob/a75d4b3711ff/tekton-catalog/tekton-exithandler/LICENSE,Apache-2.0
 github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-kfptask/pkg/apis/kfptask,https://github.com/kubeflow/kfp-tekton/blob/a75d4b3711ff/tekton-catalog/tekton-kfptask/LICENSE,Apache-2.0
-github.com/kubeflow/pipelines/api/v2alpha1/go,https://github.com/kubeflow/pipelines/blob/58ce09e07d03/api/LICENSE,Apache-2.0
+github.com/kubeflow/pipelines/api/v2alpha1/go,https://github.com/kubeflow/pipelines/blob/873e9dedd766/api/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/backend,https://github.com/kubeflow/pipelines/blob/HEAD/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform,https://github.com/kubeflow/pipelines/blob/8b2a099e8c9f/kubernetes_platform/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata,https://github.com/kubeflow/pipelines/blob/e1f0c010f800/third_party/ml-metadata/LICENSE,Apache-2.0

--- a/backend/third_party_licenses/driver.csv
+++ b/backend/third_party_licenses/driver.csv
@@ -31,7 +31,7 @@ github.com/grpc-ecosystem/grpc-gateway,https://github.com/grpc-ecosystem/grpc-ga
 github.com/jmespath/go-jmespath,https://github.com/jmespath/go-jmespath/blob/v0.4.0/LICENSE,Apache-2.0
 github.com/josharian/intern,https://github.com/josharian/intern/blob/v1.0.0/license.md,MIT
 github.com/json-iterator/go,https://github.com/json-iterator/go/blob/v1.1.12/LICENSE,MIT
-github.com/kubeflow/pipelines/api/v2alpha1/go,https://github.com/kubeflow/pipelines/blob/58ce09e07d03/api/LICENSE,Apache-2.0
+github.com/kubeflow/pipelines/api/v2alpha1/go,https://github.com/kubeflow/pipelines/blob/873e9dedd766/api/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/backend,https://github.com/kubeflow/pipelines/blob/HEAD/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform,https://github.com/kubeflow/pipelines/blob/8b2a099e8c9f/kubernetes_platform/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata,https://github.com/kubeflow/pipelines/blob/e1f0c010f800/third_party/ml-metadata/LICENSE,Apache-2.0

--- a/backend/third_party_licenses/launcher.csv
+++ b/backend/third_party_licenses/launcher.csv
@@ -29,7 +29,7 @@ github.com/grpc-ecosystem/grpc-gateway,https://github.com/grpc-ecosystem/grpc-ga
 github.com/jmespath/go-jmespath,https://github.com/jmespath/go-jmespath/blob/v0.4.0/LICENSE,Apache-2.0
 github.com/josharian/intern,https://github.com/josharian/intern/blob/v1.0.0/license.md,MIT
 github.com/json-iterator/go,https://github.com/json-iterator/go/blob/v1.1.12/LICENSE,MIT
-github.com/kubeflow/pipelines/api/v2alpha1/go,https://github.com/kubeflow/pipelines/blob/58ce09e07d03/api/LICENSE,Apache-2.0
+github.com/kubeflow/pipelines/api/v2alpha1/go,https://github.com/kubeflow/pipelines/blob/873e9dedd766/api/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/backend,https://github.com/kubeflow/pipelines/blob/HEAD/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata,https://github.com/kubeflow/pipelines/blob/e1f0c010f800/third_party/ml-metadata/LICENSE,Apache-2.0
 github.com/mailru/easyjson,https://github.com/mailru/easyjson/blob/v0.7.7/LICENSE,MIT

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/kubeflow/kfp-tekton/tekton-catalog/pipeline-loops v0.0.0-20231127195001-a75d4b3711ff
 	github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-exithandler v0.0.0-20231127195001-a75d4b3711ff
 	github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-kfptask v0.0.0-20231127195001-a75d4b3711ff
-	github.com/kubeflow/pipelines/api v0.0.0-20231027040853-58ce09e07d03
+	github.com/kubeflow/pipelines/api v0.0.0-20250102152816-873e9dedd766
 	github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240403164522-8b2a099e8c9f
 	github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20230810215105-e1f0c010f800
 	github.com/lestrrat-go/strftime v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -2036,8 +2036,8 @@ github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-exithandler v0.0.0-20231127
 github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-exithandler v0.0.0-20231127195001-a75d4b3711ff/go.mod h1:a6DSo/UxoG4hkJXJMo4nSmHURDEEiEVremmXy4GwdII=
 github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-kfptask v0.0.0-20231127195001-a75d4b3711ff h1:9gC2hCj8pnbfUKIFQKbmGjlR4p7Vr5v0u9hyLygnybw=
 github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-kfptask v0.0.0-20231127195001-a75d4b3711ff/go.mod h1:lAFdPugzj3bcAXyN3+8y0NByidZ88zwGxMc+gdc8cHw=
-github.com/kubeflow/pipelines/api v0.0.0-20231027040853-58ce09e07d03 h1:reL3LbkRIozBkKSUYjtQFV2kVC1R4WHG9FrTClRT1FY=
-github.com/kubeflow/pipelines/api v0.0.0-20231027040853-58ce09e07d03/go.mod h1:T7TOQB36gGe97yUdfVAnYK5uuT0+uQbLNHDUHxYkmE4=
+github.com/kubeflow/pipelines/api v0.0.0-20250102152816-873e9dedd766 h1:ZXz+Ki+hxez8vsr5hWHsjYWpa9V/dkp3iI4XTtMBH7A=
+github.com/kubeflow/pipelines/api v0.0.0-20250102152816-873e9dedd766/go.mod h1:puPWVUzB1VCb8lVq4g06IR2rIXuSpejDTd/FkSr6nvc=
 github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240403164522-8b2a099e8c9f h1:O5GmJN8tALpiqL0dUo4uhOkqHG8xOkNCgT7QI9q9GnE=
 github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240403164522-8b2a099e8c9f/go.mod h1:CJkKr356RlpZP/gQRuHf3Myrn1qJtoUVe4EMCmtwarg=
 github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20230810215105-e1f0c010f800 h1:YAW+X9xCW8Yq5tQaBBQaLTNU9CJj8Nr7lx1+k66ZHJ0=

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -3382,31 +3382,31 @@ class TestResourceConfig(unittest.TestCase):
             ['exec-return-1']['container'])
 
         self.assertEqual(
-            5, dict_format['deploymentSpec']['executors']['exec-return-1-2']
-            ['container']['resources']['cpuLimit'])
+            '5', dict_format['deploymentSpec']['executors']['exec-return-1-2']
+            ['container']['resources']['resourceCpuLimit'])
         self.assertNotIn(
             'memoryLimit', dict_format['deploymentSpec']['executors']
             ['exec-return-1-2']['container']['resources'])
 
         self.assertEqual(
-            50, dict_format['deploymentSpec']['executors']['exec-return-1-3']
-            ['container']['resources']['memoryLimit'])
+            '50G', dict_format['deploymentSpec']['executors']['exec-return-1-3']
+            ['container']['resources']['resourceMemoryLimit'])
         self.assertNotIn(
             'cpuLimit', dict_format['deploymentSpec']['executors']
             ['exec-return-1-3']['container']['resources'])
 
         self.assertEqual(
-            2, dict_format['deploymentSpec']['executors']['exec-return-1-4']
-            ['container']['resources']['cpuRequest'])
+            '2', dict_format['deploymentSpec']['executors']['exec-return-1-4']
+            ['container']['resources']['resourceCpuRequest'])
         self.assertEqual(
-            5, dict_format['deploymentSpec']['executors']['exec-return-1-4']
-            ['container']['resources']['cpuLimit'])
+            '5', dict_format['deploymentSpec']['executors']['exec-return-1-4']
+            ['container']['resources']['resourceCpuLimit'])
         self.assertEqual(
-            4, dict_format['deploymentSpec']['executors']['exec-return-1-4']
-            ['container']['resources']['memoryRequest'])
+            '4G', dict_format['deploymentSpec']['executors']['exec-return-1-4']
+            ['container']['resources']['resourceMemoryRequest'])
         self.assertEqual(
-            50, dict_format['deploymentSpec']['executors']['exec-return-1-4']
-            ['container']['resources']['memoryLimit'])
+            '50G', dict_format['deploymentSpec']['executors']['exec-return-1-4']
+            ['container']['resources']['resourceMemoryLimit'])
 
 
 class TestPlatformConfig(unittest.TestCase):

--- a/sdk/python/kfp/compiler/compiler_utils.py
+++ b/sdk/python/kfp/compiler/compiler_utils.py
@@ -772,3 +772,34 @@ def get_dependencies(
             dependencies[downstream_names[0]].add(upstream_names[0])
 
     return dependencies
+
+
+def recursive_replace_placeholders(data: Union[Dict, List], old_value: str,
+                                   new_value: str) -> Union[Dict, List]:
+    """Recursively replaces values in a nested dict/list object.
+
+    This method is used to replace PipelineChannel objects with input parameter
+    placeholders in a nested object like worker_pool_specs for custom jobs.
+
+    Args:
+        data: A nested object that can contain dictionaries and/or lists.
+        old_value: The value that will be replaced.
+        new_value: The value to replace the old value with.
+
+    Returns:
+        A copy of data with all occurences of old_value replaced by new_value.
+    """
+    if isinstance(data, dict):
+        return {
+            k: recursive_replace_placeholders(v, old_value, new_value)
+            for k, v in data.items()
+        }
+    elif isinstance(data, list):
+        return [
+            recursive_replace_placeholders(i, old_value, new_value)
+            for i in data
+        ]
+    else:
+        if isinstance(data, pipeline_channel.PipelineChannel):
+            data = str(data)
+        return new_value if data == old_value else data

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -617,23 +617,25 @@ def build_container_spec_for_task(
 
     if task.container_spec.resources is not None:
         if task.container_spec.resources.cpu_request is not None:
-            container_spec.resources.cpu_request = (
+            container_spec.resources.resource_cpu_request = convert_to_placeholder(
                 task.container_spec.resources.cpu_request)
         if task.container_spec.resources.cpu_limit is not None:
-            container_spec.resources.cpu_limit = (
+            container_spec.resources.resource_cpu_limit = convert_to_placeholder(
                 task.container_spec.resources.cpu_limit)
         if task.container_spec.resources.memory_request is not None:
-            container_spec.resources.memory_request = (
+            container_spec.resources.resource_memory_request = convert_to_placeholder(
                 task.container_spec.resources.memory_request)
         if task.container_spec.resources.memory_limit is not None:
-            container_spec.resources.memory_limit = (
+            container_spec.resources.resource_memory_limit = convert_to_placeholder(
                 task.container_spec.resources.memory_limit)
         if task.container_spec.resources.accelerator_count is not None:
             container_spec.resources.accelerator.CopyFrom(
                 pipeline_spec_pb2.PipelineDeploymentConfig.PipelineContainerSpec
                 .ResourceSpec.AcceleratorConfig(
-                    type=task.container_spec.resources.accelerator_type,
-                    count=task.container_spec.resources.accelerator_count,
+                    resource_type=convert_to_placeholder(
+                        task.container_spec.resources.accelerator_type),
+                    resource_count=convert_to_placeholder(
+                        task.container_spec.resources.accelerator_count),
                 ))
 
     return container_spec

--- a/sdk/python/test_data/pipelines/pipeline_with_resource_spec.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_resource_spec.yaml
@@ -61,12 +61,12 @@ deploymentSpec:
         image: gcr.io/my-project/my-fancy-trainer
         resources:
           accelerator:
-            count: '1'
-            type: tpu-v3
-          cpuLimit: 4.0
-          cpuRequest: 2.0
-          memoryLimit: 15.032385536
-          memoryRequest: 4.294967296
+            resourceCount: '1'
+            resourceType: tpu-v3
+          resourceCpuLimit: '4'
+          resourceCpuRequest: '2'
+          resourceMemoryLimit: 14Gi
+          resourceMemoryRequest: 4Gi
 pipelineInfo:
   description: A linear two-step pipeline with resource specification.
   name: two-step-pipeline-with-resource-spec
@@ -119,4 +119,4 @@ root:
         isOptional: true
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-rc.2
+sdkVersion: kfp-2.11.0


### PR DESCRIPTION
The API introduced new fields prefixed with Resource (e.g. ResourceCpuLimit) to replace the old fields without the prefix. The Driver hadn't been updated to honor those fields but the SDK started using them which led to unexpected behavior.

The Driver now honors both fields but prioritizes the new fields. The SDK now only sets the new fields.

The outcome is that resource limits/requests can now use input parameters.

Note that pipeline_spec_builder.py was doing some validation on the limits/requests being set, but that's already handled in the user facing method (e.g. set_cpu_limit).

Resolves:
https://github.com/kubeflow/pipelines/issues/11500

**Description of your changes:**


**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
