### PR TITLE
Revert swf fixes

### DIFF
--- a/backend/src/apiserver/client/scheduled_workflow_fake.go
+++ b/backend/src/apiserver/client/scheduled_workflow_fake.go
@@ -66,9 +66,9 @@ func (c *FakeScheduledWorkflowClient) Get(ctx context.Context, name string, opti
 	return nil, k8errors.NewNotFound(k8schema.ParseGroupResource("scheduledworkflows.kubeflow.org"), name)
 }
 
-func (c *FakeScheduledWorkflowClient) Update(_ context.Context, scheduledWorkflow *v1beta1.ScheduledWorkflow) (*v1beta1.ScheduledWorkflow, error) {
-	c.scheduledWorkflows[scheduledWorkflow.Name] = scheduledWorkflow
-	return scheduledWorkflow, nil
+func (c *FakeScheduledWorkflowClient) Update(context.Context, *v1beta1.ScheduledWorkflow) (*v1beta1.ScheduledWorkflow, error) {
+	glog.Error("This fake method is not yet implemented.")
+	return nil, nil
 }
 
 func (c *FakeScheduledWorkflowClient) DeleteCollection(ctx context.Context, options *v1.DeleteOptions, listOptions v1.ListOptions) error {

--- a/backend/src/apiserver/list/list.go
+++ b/backend/src/apiserver/list/list.go
@@ -22,7 +22,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"math"
 	"reflect"
 	"strings"
 
@@ -96,13 +95,6 @@ func (t *token) marshal() (string, error) {
 type Options struct {
 	PageSize int
 	*token
-}
-
-func EmptyOptions() *Options {
-	return &Options{
-		math.MaxInt32,
-		&token{},
-	}
 }
 
 // Matches returns trues if the sorting and filtering criteria in o matches that
@@ -221,14 +213,9 @@ func (o *Options) AddSortingToSelect(sqlBuilder sq.SelectBuilder) sq.SelectBuild
 	if o.IsDesc {
 		order = "DESC"
 	}
-
-	if o.SortByFieldName != "" {
-		sqlBuilder = sqlBuilder.OrderBy(fmt.Sprintf("%v %v", o.SortByFieldPrefix+o.SortByFieldName, order))
-	}
-
-	if o.KeyFieldName != "" {
-		sqlBuilder = sqlBuilder.OrderBy(fmt.Sprintf("%v %v", o.KeyFieldPrefix+o.KeyFieldName, order))
-	}
+	sqlBuilder = sqlBuilder.
+		OrderBy(fmt.Sprintf("%v %v", o.SortByFieldPrefix+o.SortByFieldName, order)).
+		OrderBy(fmt.Sprintf("%v %v", o.KeyFieldPrefix+o.KeyFieldName, order))
 
 	return sqlBuilder
 }

--- a/backend/src/apiserver/list/list_test.go
+++ b/backend/src/apiserver/list/list_test.go
@@ -15,8 +15,6 @@
 package list
 
 import (
-	"fmt"
-	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -645,11 +643,6 @@ func TestAddPaginationAndFilterToSelect(t *testing.T) {
 				},
 			},
 			wantSQL:  "SELECT * FROM MyTable ORDER BY SortField DESC, KeyField DESC LIMIT 124",
-			wantArgs: nil,
-		},
-		{
-			in:       EmptyOptions(),
-			wantSQL:  fmt.Sprintf("SELECT * FROM MyTable LIMIT %d", math.MaxInt32+1),
 			wantArgs: nil,
 		},
 		{

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
@@ -138,25 +137,10 @@ func main() {
 	}
 	log.SetLevel(level)
 
-	backgroundCtx, backgroundCancel := context.WithCancel(context.Background())
-	defer backgroundCancel()
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go reconcileSwfCrs(resourceManager, backgroundCtx, &wg)
 	go startRpcServer(resourceManager, tlsConfig)
-	// This is blocking
 	startHttpProxy(resourceManager, tlsConfig)
-	backgroundCancel()
-	clientManager.Close()
-	wg.Wait()
-}
 
-func reconcileSwfCrs(resourceManager *resource.ResourceManager, ctx context.Context, wg *sync.WaitGroup) {
-	defer wg.Done()
-	err := resourceManager.ReconcileSwfCrs(ctx)
-	if err != nil {
-		log.Errorf("Could not reconcile the ScheduledWorkflow Kubernetes resources: %v", err)
-	}
+	clientManager.Close()
 }
 
 // A custom http request header matcher to pass on the user identity

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1022,19 +1022,18 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 	for _, modelRef := range job.ResourceReferences {
 		modelRef.ResourceUUID = string(swf.UID)
 	}
-	if tmpl.GetTemplateType() == template.V1 {
-		// Get the service account
-		serviceAccount := ""
-		if swf.Spec.Workflow != nil {
-			execSpec, err := util.ScheduleSpecToExecutionSpec(util.ArgoWorkflow, swf.Spec.Workflow)
-			if err == nil {
-				serviceAccount = execSpec.ServiceAccount()
-			}
+	// Get the service account
+	serviceAccount := ""
+	if swf.Spec.Workflow != nil {
+		execSpec, err := util.ScheduleSpecToExecutionSpec(util.ArgoWorkflow, swf.Spec.Workflow)
+		if err == nil {
+			serviceAccount = execSpec.ServiceAccount()
 		}
-		job.ServiceAccount = serviceAccount
+	}
+	job.ServiceAccount = serviceAccount
+	if tmpl.GetTemplateType() == template.V1 {
 		job.PipelineSpec.WorkflowSpecManifest = manifest
 	} else {
-		job.ServiceAccount = newScheduledWorkflow.Spec.ServiceAccount
 		job.PipelineSpec.PipelineSpecManifest = manifest
 	}
 	return r.jobStore.CreateJob(job)

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -3200,35 +3200,6 @@ func TestReportScheduledWorkflowResource_Success_withRuntimeParamsV2(t *testing.
 	assert.Equal(t, expectedJob.ToV1(), actualJob.ToV1())
 }
 
-func TestReconcileSwfCrs(t *testing.T) {
-	store, manager, job := initWithJobV2(t)
-	defer store.Close()
-
-	fetchedJob, err := manager.GetJob(job.UUID)
-	require.Nil(t, err)
-	require.NotNil(t, fetchedJob)
-
-	swfClient := store.SwfClient().ScheduledWorkflow("ns1")
-
-	options := v1.GetOptions{}
-	ctx := context.Background()
-
-	swf, err := swfClient.Get(ctx, "job-", options)
-	require.Nil(t, err)
-
-	// emulates an invalid/outdated spec
-	swf.Spec.Workflow.Spec = nil
-	swf, err = swfClient.Update(ctx, swf)
-	require.Nil(t, swf.Spec.Workflow.Spec)
-
-	err = manager.ReconcileSwfCrs(ctx)
-	require.Nil(t, err)
-
-	swf, err = swfClient.Get(ctx, "job-", options)
-	require.Nil(t, err)
-	require.NotNil(t, swf.Spec.Workflow.Spec)
-}
-
 func TestReportScheduledWorkflowResource_Error(t *testing.T) {
 	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
 	defer store.Close()

--- a/backend/src/apiserver/template/template_test.go
+++ b/backend/src/apiserver/template/template_test.go
@@ -220,10 +220,9 @@ func TestScheduledWorkflow(t *testing.T) {
 				Parameters: []scheduledworkflow.Parameter{{Name: "y", Value: "\"world\""}},
 				Spec:       "",
 			},
-			PipelineId:     "1",
-			PipelineName:   "pipeline name",
-			NoCatchup:      util.BoolPointer(true),
-			ServiceAccount: "pipeline-runner",
+			PipelineId:   "1",
+			PipelineName: "pipeline name",
+			NoCatchup:    util.BoolPointer(true),
 		},
 	}
 

--- a/backend/src/apiserver/template/v2_template.go
+++ b/backend/src/apiserver/template/v2_template.go
@@ -97,9 +97,7 @@ func (t *V2Spec) ScheduledWorkflow(modelJob *model.Job, ownerReferences []metav1
 	if modelJob.Namespace != "" {
 		executionSpec.SetExecutionNamespace(modelJob.Namespace)
 	}
-	if executionSpec.ServiceAccount() == "" {
-		setDefaultServiceAccount(executionSpec, modelJob.ServiceAccount)
-	}
+	setDefaultServiceAccount(executionSpec, modelJob.ServiceAccount)
 	// Disable istio sidecar injection if not specified
 	executionSpec.SetAnnotationsToAllTemplatesIfKeyNotExist(util.AnnotationKeyIstioSidecarInject, util.AnnotationValueIstioSidecarInjectDisabled)
 	swfGeneratedName, err := toSWFCRDResourceGeneratedName(modelJob.K8SName)
@@ -137,7 +135,7 @@ func (t *V2Spec) ScheduledWorkflow(modelJob *model.Job, ownerReferences []metav1
 			PipelineId:        modelJob.PipelineId,
 			PipelineName:      modelJob.PipelineName,
 			PipelineVersionId: modelJob.PipelineVersionId,
-			ServiceAccount:    executionSpec.ServiceAccount(),
+			ServiceAccount:    modelJob.ServiceAccount,
 		},
 	}
 	return scheduledWorkflow, nil


### PR DESCRIPTION
Reverts the following commits:

- [UPSTREAM: 11469: fix(backend): Synced ScheduledWorkflow CRs on apiserver startup](https://github.com/opendatahub-io/data-science-pipelines/commit/8ab8dae806e55e00b9e8c3d2c1f0244cb1636903)
- [chore(backend): Fixed ServiceAccount in job creation](https://github.com/opendatahub-io/data-science-pipelines/commit/37c74b3aa075c91e3034cbd03c13e201e007d31c)
- [UPSTREAM: 11480: chore(backend): Fixed namespace in job creation](https://github.com/opendatahub-io/data-science-pipelines/commit/34bf2f8d6b5b2f35fb3e6ff641e6bda09cb4a24e)