### PR TITLE
Cherry-pick of (#11714): Ignore empty PULL_NUMBER environment variables in SDK tests

### DIFF
--- a/test/kfp-kubernetes-execution-tests/sdk_execution_tests.py
+++ b/test/kfp-kubernetes-execution-tests/sdk_execution_tests.py
@@ -111,7 +111,7 @@ def run(test_case: TestCase) -> Tuple[str, client.client.RunPipelineResult]:
 
 def get_kfp_package_path() -> str:
     repo_name = os.environ.get('REPO_NAME', 'kubeflow/pipelines')
-    if os.environ.get('PULL_NUMBER') is not None:
+    if os.environ.get('PULL_NUMBER'):
         path = f'git+https://github.com/{repo_name}.git@refs/pull/{os.environ["PULL_NUMBER"]}/merge#subdirectory=sdk/python'
     else:
         path = f'git+https://github.com/{repo_name}.git@master#subdirectory=sdk/python'

--- a/test/sdk-execution-tests/sdk_execution_tests.py
+++ b/test/sdk-execution-tests/sdk_execution_tests.py
@@ -100,7 +100,7 @@ def run(test_case: TestCase) -> Tuple[str, client.client.RunPipelineResult]:
 
 def get_kfp_package_path() -> str:
     repo_name = os.environ.get('REPO_NAME', 'kubeflow/pipelines')
-    if os.environ.get('PULL_NUMBER') is not None:
+    if os.environ.get('PULL_NUMBER'):
         path = f'git+https://github.com/{repo_name}.git@refs/pull/{os.environ["PULL_NUMBER"]}/merge#subdirectory=sdk/python'
     else:
         path = f'git+https://github.com/{repo_name}.git@master#subdirectory=sdk/python'


### PR DESCRIPTION
**Description of your changes:**

Cherry-pick of https://github.com/kubeflow/pipelines/commit/a7ec34f571c367e9f1957019992f3823865f4a5c.

On pushes to the master branch, PULL_NUMBER was an empty string. 

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 