### PR TITLE
[Cherry-pick Upstream] Fix recurring run output when always using latest (#11790)

### DIFF
--- a/backend/src/apiserver/server/api_converter.go
+++ b/backend/src/apiserver/server/api_converter.go
@@ -2194,7 +2194,7 @@ func toApiRecurringRun(j *model.Job) *apiv2beta1.RecurringRun {
 		ExperimentId:   j.ExperimentId,
 	}
 
-	if j.PipelineSpec.PipelineVersionId == "" {
+	if j.PipelineSpec.PipelineId == "" && j.PipelineSpec.PipelineVersionId == "" {
 		spec, err := yamlStringToPipelineSpecStruct(j.PipelineSpec.PipelineSpecManifest)
 		if err != nil {
 			return &apiv2beta1.RecurringRun{

--- a/backend/src/apiserver/server/api_converter_test.go
+++ b/backend/src/apiserver/server/api_converter_test.go
@@ -2164,6 +2164,11 @@ func TestToApiRecurringRun(t *testing.T) {
 		UpdatedAt:      &timestamp.Timestamp{Seconds: 2},
 		MaxConcurrency: 2,
 		NoCatchup:      true,
+		PipelineSource: &apiv2beta1.RecurringRun_PipelineVersionReference{
+			PipelineVersionReference: &apiv2beta1.PipelineVersionReference{
+				PipelineId: "1",
+			},
+		},
 		Trigger: &apiv2beta1.Trigger{
 			Trigger: &apiv2beta1.Trigger_CronSchedule{CronSchedule: &apiv2beta1.CronSchedule{
 				StartTime: &timestamp.Timestamp{Seconds: 2},

--- a/backend/test/v2/integration/recurring_run_api_test.go
+++ b/backend/test/v2/integration/recurring_run_api_test.go
@@ -407,6 +407,8 @@ func (s *RecurringRunApiTestSuite) TestRecurringRunApisUseLatest() {
 	}}
 	helloWorldRecurringRun, err := s.recurringRunClient.Create(createRecurringRunRequest)
 	assert.Nil(t, err)
+	assert.Equal(t, helloWorldPipelineVersion.PipelineID, helloWorldRecurringRun.PipelineVersionReference.PipelineID)
+	assert.Empty(t, helloWorldRecurringRun.PipelineVersionReference.PipelineVersionID)
 
 	// The scheduledWorkflow CRD would create the run and it synced to the DB by persistent agent.
 	// This could take a few seconds to finish.


### PR DESCRIPTION
Cherry-pick of https://github.com/kubeflow/pipelines/pull/11790