### PR TITLE
Remove Podman as backend README pre-req

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -10,7 +10,7 @@ This README will help you set up your coding environment in order to build and r
 ## Prerequisites
 Before you begin, ensure you have:
 - [Go installed](https://go.dev/doc/install)
-- Docker or Podman installed (for building container images)
+- Docker installed (for building container images)
 
 Note that you may need to restart your shell after installing these resources in order for the changes to take effect.
 


### PR DESCRIPTION
**Description of your changes:**
Remove Podman as an alternative for Docker in the  backend README prerequisites. KFP backend does not run successfully locally using Podman.

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
