### PR TITLE
Cherry pick Toleration list support

### DIFF
--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -84,6 +84,6 @@ API generator image is defined in [Dockerfile](`./Dockerfile`). If you need to u
 1. Login to GHCR container registry: `echo "<PAT>" | docker login ghcr.io -u <USERNAME> --password-stdin` 
    * Replace `<PAT>` with a GitHub Personal Access Token (PAT) with the write:packages and `read:packages` scopes, as well as `delete:packages` if needed. 
 1. Update the [Dockerfile](`./Dockerfile`) and build the image by running `docker build -t ghcr.io/kubeflow/kfp-api-generator:$VERSION .`
-1. Push the new container by running `docker push ghcr.io/kubeflow/kfp-api-generator:$VERSION` (requires to be [authenticated](https://cloud.google.com/container-registry/docs/advanced-authentication)).
+1. Push the new container by running `docker push ghcr.io/kubeflow/kfp-api-generator:$VERSION`.
 1. Update the `PREBUILT_REMOTE_IMAGE` variable in the [Makefile](./Makefile) to point to your new image.
 1. Similarly, push a new version of the release tools image to `ghcr.io/kubeflow/kfp-release:$VERSION` and run `make push` in [test/release/Makefile](../../test/release/Makefile).

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -785,10 +785,41 @@ func extendPodSpecPatch(
 			if toleration != nil {
 				k8sToleration := &k8score.Toleration{}
 				if toleration.TolerationJson != nil {
-					err := resolveK8sJsonParameter(ctx, opts, dag, pipeline, mlmd,
-						toleration.GetTolerationJson(), inputParams, k8sToleration)
+					resolvedParam, err := resolveInputParameter(ctx, dag, pipeline, opts, mlmd,
+						toleration.GetTolerationJson(), inputParams)
 					if err != nil {
 						return fmt.Errorf("failed to resolve toleration: %w", err)
+					}
+
+					// TolerationJson can be either a single toleration or list of tolerations
+					// the field accepts both, and in both cases the tolerations are appended
+					// to the total executor pod toleration list.
+					var paramJSON []byte
+					isSingleToleration := resolvedParam.GetStructValue() != nil
+					isListToleration := resolvedParam.GetListValue() != nil
+					if isSingleToleration {
+						paramJSON, err = resolvedParam.GetStructValue().MarshalJSON()
+						if err != nil {
+							return err
+						}
+						var singleToleration k8score.Toleration
+						if err = json.Unmarshal(paramJSON, &singleToleration); err != nil {
+							return fmt.Errorf("failed to marshal single toleration to json: %w", err)
+						}
+						k8sTolerations = append(k8sTolerations, singleToleration)
+					} else if isListToleration {
+						paramJSON, err = resolvedParam.GetListValue().MarshalJSON()
+						if err != nil {
+							return err
+						}
+						var k8sTolerationsList []k8score.Toleration
+						if err = json.Unmarshal(paramJSON, &k8sTolerationsList); err != nil {
+							return fmt.Errorf("failed to marshal list toleration to json: %w", err)
+						}
+						k8sTolerations = append(k8sTolerations, k8sTolerationsList...)
+					} else {
+						return fmt.Errorf("encountered unexpected toleration proto value, "+
+							"must be either struct or list type: %w", err)
 					}
 				} else {
 					k8sToleration.Key = toleration.Key
@@ -796,8 +827,9 @@ func extendPodSpecPatch(
 					k8sToleration.Value = toleration.Value
 					k8sToleration.Effect = k8score.TaintEffect(toleration.Effect)
 					k8sToleration.TolerationSeconds = toleration.TolerationSeconds
+					k8sTolerations = append(k8sTolerations, *k8sToleration)
 				}
-				k8sTolerations = append(k8sTolerations, *k8sToleration)
+
 			}
 		}
 		podSpec.Tolerations = k8sTolerations

--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -2075,6 +2075,165 @@ func Test_extendPodSpecPatch_Tolerations(t *testing.T) {
 				}),
 			},
 		},
+		{
+			"Valid - toleration json - toleration list",
+			&kubernetesplatform.KubernetesExecutorConfig{
+				Tolerations: []*kubernetesplatform.Toleration{
+					{
+						TolerationJson: inputParamComponent("param_1"),
+					},
+				},
+			},
+			&k8score.PodSpec{
+				Containers: []k8score.Container{
+					{
+						Name: "main",
+					},
+				},
+				Tolerations: []k8score.Toleration{
+					{
+						Key:               "key1",
+						Operator:          "Equal",
+						Value:             "value1",
+						Effect:            "NoSchedule",
+						TolerationSeconds: int64Ptr(3601),
+					},
+					{
+						Key:               "key2",
+						Operator:          "Equal",
+						Value:             "value2",
+						Effect:            "NoSchedule",
+						TolerationSeconds: int64Ptr(3602),
+					},
+					{
+						Key:               "key3",
+						Operator:          "Equal",
+						Value:             "value3",
+						Effect:            "NoSchedule",
+						TolerationSeconds: int64Ptr(3603),
+					},
+				},
+			},
+			map[string]*structpb.Value{
+				"param_1": validListOfStructsOrPanic([]map[string]interface{}{
+					{
+						"key":               "key1",
+						"operator":          "Equal",
+						"value":             "value1",
+						"effect":            "NoSchedule",
+						"tolerationSeconds": 3601,
+					},
+					{
+						"key":               "key2",
+						"operator":          "Equal",
+						"value":             "value2",
+						"effect":            "NoSchedule",
+						"tolerationSeconds": 3602,
+					},
+					{
+						"key":               "key3",
+						"operator":          "Equal",
+						"value":             "value3",
+						"effect":            "NoSchedule",
+						"tolerationSeconds": 3603,
+					},
+				}),
+			},
+		},
+		{
+			"Valid - toleration json - list toleration & single toleration & constant toleration",
+			&kubernetesplatform.KubernetesExecutorConfig{
+				Tolerations: []*kubernetesplatform.Toleration{
+					{
+						TolerationJson: inputParamComponent("param_1"),
+					},
+					{
+						TolerationJson: inputParamComponent("param_2"),
+					},
+					{
+						Key:      "key5",
+						Operator: "Equal",
+						Value:    "value5",
+						Effect:   "NoSchedule",
+					},
+				},
+			},
+			&k8score.PodSpec{
+				Containers: []k8score.Container{
+					{
+						Name: "main",
+					},
+				},
+				Tolerations: []k8score.Toleration{
+					{
+						Key:               "key1",
+						Operator:          "Equal",
+						Value:             "value1",
+						Effect:            "NoSchedule",
+						TolerationSeconds: int64Ptr(3601),
+					},
+					{
+						Key:               "key2",
+						Operator:          "Equal",
+						Value:             "value2",
+						Effect:            "NoSchedule",
+						TolerationSeconds: int64Ptr(3602),
+					},
+					{
+						Key:               "key3",
+						Operator:          "Equal",
+						Value:             "value3",
+						Effect:            "NoSchedule",
+						TolerationSeconds: int64Ptr(3603),
+					},
+					{
+						Key:               "key4",
+						Operator:          "Equal",
+						Value:             "value4",
+						Effect:            "NoSchedule",
+						TolerationSeconds: int64Ptr(3604),
+					},
+					{
+						Key:      "key5",
+						Operator: "Equal",
+						Value:    "value5",
+						Effect:   "NoSchedule",
+					},
+				},
+			},
+			map[string]*structpb.Value{
+				"param_1": validListOfStructsOrPanic([]map[string]interface{}{
+					{
+						"key":               "key1",
+						"operator":          "Equal",
+						"value":             "value1",
+						"effect":            "NoSchedule",
+						"tolerationSeconds": 3601,
+					},
+					{
+						"key":               "key2",
+						"operator":          "Equal",
+						"value":             "value2",
+						"effect":            "NoSchedule",
+						"tolerationSeconds": 3602,
+					},
+					{
+						"key":               "key3",
+						"operator":          "Equal",
+						"value":             "value3",
+						"effect":            "NoSchedule",
+						"tolerationSeconds": 3603,
+					},
+				}),
+				"param_2": validValueStructOrPanic(map[string]interface{}{
+					"key":               "key4",
+					"operator":          "Equal",
+					"value":             "value4",
+					"effect":            "NoSchedule",
+					"tolerationSeconds": 3604,
+				}),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2552,6 +2711,18 @@ func Test_extendPodSpecPatch_GenericEphemeralVolume(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.podSpec)
 		})
 	}
+}
+
+func validListOfStructsOrPanic(data []map[string]interface{}) *structpb.Value {
+	var listValues []*structpb.Value
+	for _, item := range data {
+		s, err := structpb.NewStruct(item)
+		if err != nil {
+			panic(err)
+		}
+		listValues = append(listValues, structpb.NewStructValue(s))
+	}
+	return structpb.NewListValue(&structpb.ListValue{Values: listValues})
 }
 
 func validValueStructOrPanic(data map[string]interface{}) *structpb.Value {

--- a/backend/test/integration/pipeline_api_test.go
+++ b/backend/test/integration/pipeline_api_test.go
@@ -122,7 +122,7 @@ func (s *PipelineApiTest) TestPipelineAPI() {
 	time.Sleep(1 * time.Second)
 	sequentialPipeline, err := s.pipelineClient.Create(&params.PipelineServiceCreatePipelineV1Params{
 		Body: &model.APIPipeline{Name: "sequential", URL: &model.APIURL{
-			PipelineURL: "https://storage.googleapis.com/ml-pipeline-dataset/sequential.yaml",
+			PipelineURL: "https://raw.githubusercontent.com/kubeflow/pipelines/refs/heads/master/backend/test/v2/resources/sequential.yaml",
 		}},
 	})
 	require.Nil(t, err)
@@ -139,7 +139,7 @@ func (s *PipelineApiTest) TestPipelineAPI() {
 	time.Sleep(1 * time.Second)
 	argumentUrlPipeline, err := s.pipelineClient.Create(&params.PipelineServiceCreatePipelineV1Params{
 		Body: &model.APIPipeline{URL: &model.APIURL{
-			PipelineURL: "https://storage.googleapis.com/ml-pipeline-dataset/arguments.pipeline.zip",
+			PipelineURL: "https://github.com/kubeflow/pipelines/raw/refs/heads/master/backend/test/v2/resources/arguments.pipeline.zip",
 		}},
 	})
 	require.Nil(t, err)

--- a/backend/test/integration/pipeline_version_api_test.go
+++ b/backend/test/integration/pipeline_version_api_test.go
@@ -145,7 +145,7 @@ func (s *PipelineVersionApiTest) TestArgoSpec() {
 		Body: &pipeline_model.APIPipelineVersion{
 			Name: "sequential",
 			PackageURL: &pipeline_model.APIURL{
-				PipelineURL: "https://storage.googleapis.com/ml-pipeline-dataset/sequential.yaml",
+				PipelineURL: "https://raw.githubusercontent.com/kubeflow/pipelines/refs/heads/master/backend/test/v2/resources/sequential.yaml",
 			},
 			ResourceReferences: []*pipeline_model.APIResourceReference{
 				{
@@ -174,7 +174,7 @@ func (s *PipelineVersionApiTest) TestArgoSpec() {
 		Body: &pipeline_model.APIPipelineVersion{
 			Name: "arguments",
 			PackageURL: &pipeline_model.APIURL{
-				PipelineURL: "https://storage.googleapis.com/ml-pipeline-dataset/arguments.pipeline.zip",
+				PipelineURL: "https://github.com/kubeflow/pipelines/raw/refs/heads/master/backend/test/resources/arguments.pipeline.zip",
 			},
 			ResourceReferences: []*pipeline_model.APIResourceReference{
 				{

--- a/backend/test/integration/upgrade_test.go
+++ b/backend/test/integration/upgrade_test.go
@@ -272,7 +272,7 @@ func (s *UpgradeTests) PreparePipelines() {
 	time.Sleep(1 * time.Second)
 	sequentialPipeline, err := s.pipelineClient.Create(&pipelineParams.PipelineServiceCreatePipelineV1Params{
 		Body: &pipeline_model.APIPipeline{Name: "sequential", URL: &pipeline_model.APIURL{
-			PipelineURL: "https://storage.googleapis.com/ml-pipeline-dataset/sequential.yaml",
+			PipelineURL: "https://raw.githubusercontent.com/kubeflow/pipelines/refs/heads/master/backend/test/v2/resources/sequential.yaml",
 		}},
 	})
 	require.Nil(t, err)
@@ -289,7 +289,7 @@ func (s *UpgradeTests) PreparePipelines() {
 	time.Sleep(1 * time.Second)
 	argumentUrlPipeline, err := s.pipelineClient.Create(&pipelineParams.PipelineServiceCreatePipelineV1Params{
 		Body: &pipeline_model.APIPipeline{URL: &pipeline_model.APIURL{
-			PipelineURL: "https://storage.googleapis.com/ml-pipeline-dataset/arguments.pipeline.zip",
+			PipelineURL: "https://github.com/kubeflow/pipelines/raw/refs/heads/master/backend/test/v2/resources/arguments.pipeline.zip",
 		}},
 	})
 	require.Nil(t, err)
@@ -535,20 +535,20 @@ func (s *UpgradeTests) VerifyCreatingRunsAndJobs() {
 
 	/* ---------- Create a new recurring run based on the second oldest pipeline version and belonging to the second oldest experiment ---------- */
 	createJobRequest := &jobparams.JobServiceCreateJobParams{Body: &job_model.APIJob{
-		Name:        "sequential job from pipeline version",
-		Description: "a recurring run from an old pipeline version",
+		Description:    "a recurring run from an old pipeline version",
+		Enabled:        true,
+		MaxConcurrency: 10,
+		Name:           "sequential job from pipeline version",
 		ResourceReferences: []*job_model.APIResourceReference{
 			{
 				Key:          &job_model.APIResourceKey{Type: job_model.APIResourceTypeEXPERIMENT, ID: experiments[1].ID},
 				Relationship: job_model.APIRelationshipOWNER,
 			},
 			{
-				Key:          &job_model.APIResourceKey{Type: job_model.APIResourceTypePIPELINEVERSION, ID: pipelines[1].DefaultVersion.ID},
+				Key:          &job_model.APIResourceKey{Type: job_model.APIResourceTypePIPELINEVERSION, ID: pipelines[0].DefaultVersion.ID},
 				Relationship: job_model.APIRelationshipCREATOR,
 			},
 		},
-		MaxConcurrency: 10,
-		Enabled:        true,
 	}}
 	createdJob, err := s.jobClient.Create(createJobRequest)
 	assert.Nil(t, err)

--- a/backend/test/v2/integration/pipeline_api_test.go
+++ b/backend/test/v2/integration/pipeline_api_test.go
@@ -126,7 +126,7 @@ func (s *PipelineApiTest) TestPipelineAPI() {
 			},
 			PipelineVersion: &model.V2beta1PipelineVersion{
 				PackageURL: &model.V2beta1URL{
-					PipelineURL: "https://storage.googleapis.com/ml-pipeline-dataset/v2/sequential.yaml",
+					PipelineURL: "https://raw.githubusercontent.com/kubeflow/pipelines/refs/heads/master/backend/test/v2/resources/sequential-v2.yaml",
 				},
 			},
 		},
@@ -141,7 +141,7 @@ func (s *PipelineApiTest) TestPipelineAPI() {
 	assert.Equal(t, "sequential", sequentialPipelineVersions[0].DisplayName)
 	assert.Equal(t, "sequential pipeline", sequentialPipelineVersions[0].Description)
 	assert.Equal(t, sequentialPipeline.PipelineID, sequentialPipelineVersions[0].PipelineID)
-	assert.Equal(t, "https://storage.googleapis.com/ml-pipeline-dataset/v2/sequential.yaml", sequentialPipelineVersions[0].PackageURL.PipelineURL)
+	assert.Equal(t, "https://raw.githubusercontent.com/kubeflow/pipelines/refs/heads/master/backend/test/v2/resources/sequential-v2.yaml", sequentialPipelineVersions[0].PackageURL.PipelineURL)
 
 	/* ---------- Upload pipelines zip ---------- */
 	time.Sleep(1 * time.Second)
@@ -164,7 +164,7 @@ func (s *PipelineApiTest) TestPipelineAPI() {
 				Description: "1st version of argument url pipeline",
 				PipelineID:  sequentialPipeline.PipelineID,
 				PackageURL: &model.V2beta1URL{
-					PipelineURL: "https://storage.googleapis.com/ml-pipeline-dataset/v2/arguments.pipeline.zip",
+					PipelineURL: "https://github.com/kubeflow/pipelines/raw/refs/heads/master/backend/test/v2/resources/arguments.pipeline.zip",
 				},
 			},
 		})
@@ -172,7 +172,7 @@ func (s *PipelineApiTest) TestPipelineAPI() {
 	assert.Equal(t, "argumentUrl-v1", argumentUrlPipelineVersion.DisplayName)
 	assert.Equal(t, "1st version of argument url pipeline", argumentUrlPipelineVersion.Description)
 	assert.Equal(t, argumentUrlPipeline.PipelineID, argumentUrlPipelineVersion.PipelineID)
-	assert.Equal(t, "https://storage.googleapis.com/ml-pipeline-dataset/v2/arguments.pipeline.zip", argumentUrlPipelineVersion.PackageURL.PipelineURL)
+	assert.Equal(t, "https://github.com/kubeflow/pipelines/raw/refs/heads/master/backend/test/v2/resources/arguments.pipeline.zip", argumentUrlPipelineVersion.PackageURL.PipelineURL)
 
 	/* ---------- Verify list pipeline works ---------- */
 	pipelines, totalSize, _, err := s.pipelineClient.List(&params.PipelineServiceListPipelinesParams{})

--- a/backend/test/v2/integration/pipeline_version_api_test.go
+++ b/backend/test/v2/integration/pipeline_version_api_test.go
@@ -137,7 +137,7 @@ func (s *PipelineVersionApiTest) TestPipelineSpec() {
 		Body: &pipeline_model.V2beta1PipelineVersion{
 			DisplayName: "sequential",
 			PackageURL: &pipeline_model.V2beta1URL{
-				PipelineURL: "https://storage.googleapis.com/ml-pipeline-dataset/v2/sequential.yaml",
+				PipelineURL: "https://raw.githubusercontent.com/kubeflow/pipelines/refs/heads/master/backend/test/v2/resources/sequential-v2.yaml",
 			},
 			PipelineID: pipelineId,
 		},
@@ -162,7 +162,7 @@ func (s *PipelineVersionApiTest) TestPipelineSpec() {
 		Body: &pipeline_model.V2beta1PipelineVersion{
 			DisplayName: "arguments",
 			PackageURL: &pipeline_model.V2beta1URL{
-				PipelineURL: "https://storage.googleapis.com/ml-pipeline-dataset/v2/arguments.pipeline.zip",
+				PipelineURL: "https://github.com/kubeflow/pipelines/raw/refs/heads/master/backend/test/v2/resources/arguments.pipeline.zip",
 			},
 			PipelineID: pipelineId,
 		},

--- a/backend/test/v2/integration/upgrade_test.go
+++ b/backend/test/v2/integration/upgrade_test.go
@@ -278,7 +278,7 @@ func (s *UpgradeTests) PreparePipelines() {
 		Body: &pipeline_model.V2beta1PipelineVersion{
 			DisplayName: "sequential",
 			PackageURL: &pipeline_model.V2beta1URL{
-				PipelineURL: "https://storage.googleapis.com/ml-pipeline-dataset/v2/sequential.yaml",
+				PipelineURL: "https://raw.githubusercontent.com/kubeflow/pipelines/refs/heads/master/backend/test/v2/resources/sequential-v2.yaml",
 			},
 			PipelineID: sequentialPipeline.PipelineID,
 		},
@@ -305,7 +305,7 @@ func (s *UpgradeTests) PreparePipelines() {
 		Body: &pipeline_model.V2beta1PipelineVersion{
 			DisplayName: "arguments",
 			PackageURL: &pipeline_model.V2beta1URL{
-				PipelineURL: "https://storage.googleapis.com/ml-pipeline-dataset/v2/arguments.pipeline.zip",
+				PipelineURL: "https://github.com/kubeflow/pipelines/raw/refs/heads/master/backend/test/v2/resources/arguments.pipeline.zip",
 			},
 			PipelineID: argumentUrlPipeline.PipelineID,
 		},

--- a/backend/test/v2/resources/sequential-v2.py
+++ b/backend/test/v2/resources/sequential-v2.py
@@ -14,19 +14,28 @@
 
 from kfp import dsl, compiler
 
+
 @dsl.container_component
-def echo(message: str):
+def download(url: str, downloaded: dsl.OutputPath(str)):
+    return dsl.ContainerSpec(
+        image='google/cloud-sdk',
+        command=['sh', '-c'],
+        args=[f'gsutil cp {url} {downloaded}'],
+    )
+
+
+@dsl.container_component
+def echo(downloaded: str):
     return dsl.ContainerSpec(
         image='library/bash',
         command=['sh', '-c'],
-        args=[f'echo {message}'],
+        args=[f'echo {downloaded}'],
     )
 
 
 @dsl.pipeline
-def sequential(param1: str, param2: str):
-    echo(message=param1)
-    echo(message=param2)
+def sequential(url: str):
+    echo(downloaded=download(url=url).outputs['downloaded'])
 
 
 if __name__ == '__main__':

--- a/backend/test/v2/resources/sequential-v2.yaml
+++ b/backend/test/v2/resources/sequential-v2.yaml
@@ -1,0 +1,76 @@
+# PIPELINE DEFINITION
+# Name: sequential
+# Inputs:
+#    url: str
+components:
+  comp-download:
+    executorLabel: exec-download
+    inputDefinitions:
+      parameters:
+        url:
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        downloaded:
+          parameterType: STRING
+  comp-echo:
+    executorLabel: exec-echo
+    inputDefinitions:
+      parameters:
+        downloaded:
+          parameterType: STRING
+deploymentSpec:
+  executors:
+    exec-download:
+      container:
+        args:
+        - gsutil cp {{$.inputs.parameters['url']}} {{$.outputs.parameters['downloaded'].output_file}}
+        command:
+        - sh
+        - -c
+        image: google/cloud-sdk
+    exec-echo:
+      container:
+        args:
+        - echo {{$.inputs.parameters['downloaded']}}
+        command:
+        - sh
+        - -c
+        image: library/bash
+pipelineInfo:
+  name: sequential
+root:
+  dag:
+    tasks:
+      download:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-download
+        inputs:
+          parameters:
+            url:
+              componentInputParameter: url
+        taskInfo:
+          name: download
+      echo:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-echo
+        dependentTasks:
+        - download
+        inputs:
+          parameters:
+            downloaded:
+              taskOutputParameter:
+                outputParameterKey: downloaded
+                producerTask: download
+        taskInfo:
+          name: echo
+  inputDefinitions:
+    parameters:
+      url:
+        parameterType: STRING
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.0.0-beta.13

--- a/backend/test/v2/resources/sequential.yaml
+++ b/backend/test/v2/resources/sequential.yaml
@@ -1,38 +1,35 @@
 # PIPELINE DEFINITION
 # Name: sequential
 # Inputs:
-#    url: str
+#    param1: str
+#    param2: str
 components:
-  comp-download:
-    executorLabel: exec-download
-    inputDefinitions:
-      parameters:
-        url:
-          parameterType: STRING
-    outputDefinitions:
-      parameters:
-        downloaded:
-          parameterType: STRING
   comp-echo:
     executorLabel: exec-echo
     inputDefinitions:
       parameters:
-        downloaded:
+        message:
+          parameterType: STRING
+  comp-echo-2:
+    executorLabel: exec-echo-2
+    inputDefinitions:
+      parameters:
+        message:
           parameterType: STRING
 deploymentSpec:
   executors:
-    exec-download:
-      container:
-        args:
-        - gsutil cp {{$.inputs.parameters['url']}} {{$.outputs.parameters['downloaded'].output_file}}
-        command:
-        - sh
-        - -c
-        image: google/cloud-sdk
     exec-echo:
       container:
         args:
-        - echo {{$.inputs.parameters['downloaded']}}
+        - echo {{$.inputs.parameters['message']}}
+        command:
+        - sh
+        - -c
+        image: library/bash
+    exec-echo-2:
+      container:
+        args:
+        - echo {{$.inputs.parameters['message']}}
         command:
         - sh
         - -c
@@ -42,35 +39,33 @@ pipelineInfo:
 root:
   dag:
     tasks:
-      download:
-        cachingOptions:
-          enableCache: true
-        componentRef:
-          name: comp-download
-        inputs:
-          parameters:
-            url:
-              componentInputParameter: url
-        taskInfo:
-          name: download
       echo:
         cachingOptions:
           enableCache: true
         componentRef:
           name: comp-echo
-        dependentTasks:
-        - download
         inputs:
           parameters:
-            downloaded:
-              taskOutputParameter:
-                outputParameterKey: downloaded
-                producerTask: download
+            message:
+              componentInputParameter: param1
         taskInfo:
           name: echo
+      echo-2:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-echo-2
+        inputs:
+          parameters:
+            message:
+              componentInputParameter: param2
+        taskInfo:
+          name: echo-2
   inputDefinitions:
     parameters:
-      url:
+      param1:
+        parameterType: STRING
+      param2:
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-beta.13
+sdkVersion: kfp-2.12.2

--- a/kubernetes_platform/python/kfp/kubernetes/toleration.py
+++ b/kubernetes_platform/python/kfp/kubernetes/toleration.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from typing import Optional, Union
 
 from google.protobuf import json_format
@@ -82,21 +81,46 @@ def add_toleration(
 
 
 def add_toleration_json(task: PipelineTask,
-                        toleration_json: Union[pipeline_channel.PipelineParameterChannel, dict]
+                        toleration_json: Union[pipeline_channel.PipelineParameterChannel, list, dict]
                         ):
-    """Add a Pod Toleration in the form of a JSON to a task.
+    """Add a Pod Toleration in the form of a Pipeline Input JSON to a task.
 
     Args:
         task:
             Pipeline task.
         toleration_json:
-            a toleration provided as dict or input parameter. Takes
-            precedence over other key, operator, value, effect,
-            and toleration_seconds.
+            a toleration that is a pipeline input parameter.
+            The input parameter must be of type dict or list.
 
+            If it is a dict, it must be a single toleration object.
+            For example a pipeline input parameter in this case could be:
+                {
+                  "key": "key1",
+                  "operator": "Equal",
+                  "value": "value1",
+                  "effect": "NoSchedule"
+                }
+
+            If it is a list, it must be list of toleration objects.
+            For example a pipeline input parameter in this case could be:
+                [
+                    {
+                      "key": "key1",
+                      "operator": "Equal",
+                      "value": "value1",
+                      "effect": "NoSchedule"
+                    },
+                    {
+                      "key": "key2",
+                      "operator": "Exists",
+                      "effect": "NoExecute"
+                    }
+                ]
     Returns:
         Task object with added toleration.
     """
+    if not isinstance(toleration_json, pipeline_channel.PipelineParameterChannel):
+        raise TypeError("toleration_json must be a Pipeline Input Parameter.")
 
     msg = common.get_existing_kubernetes_config_as_message(task)
     toleration = pb.Toleration()

--- a/kubernetes_platform/python/test/unit/test_tolerations.py
+++ b/kubernetes_platform/python/test/unit/test_tolerations.py
@@ -173,7 +173,7 @@ class TestTolerationsJSON:
         # checks that a pipeline input for
         # tasks is supported
         @dsl.pipeline
-        def my_pipeline(toleration_input: str):
+        def my_pipeline(toleration_input: dict):
             task = comp()
             kubernetes.add_toleration_json(
                 task,
@@ -204,7 +204,7 @@ class TestTolerationsJSON:
         # checks that multiple pipeline inputs for
         # different tasks are supported
         @dsl.pipeline
-        def my_pipeline(toleration_input_1: str, toleration_input_2: str):
+        def my_pipeline(toleration_input_1: dict, toleration_input_2: list):
             t1 = comp()
             kubernetes.add_toleration_json(
                 t1,

--- a/kubernetes_platform/python/test/unit/test_tolerations.py
+++ b/kubernetes_platform/python/test/unit/test_tolerations.py
@@ -254,6 +254,79 @@ class TestTolerationsJSON:
             }
         }
 
+    def test_component_pipeline_input_three(self):
+        # check list or dict types for add
+        # toleration json
+        @dsl.pipeline
+        def my_pipeline(toleration_input: dict):
+            t1 = comp()
+            kubernetes.add_toleration_json(
+                t1,
+                toleration_json=toleration_input,
+            )
+            kubernetes.add_toleration_json(
+                t1,
+                toleration_json={
+                    "key": "key3",
+                    "operator": "Equal",
+                    "value": "value3",
+                    "effect": "NoSchedule"
+                },
+            )
+            kubernetes.add_toleration_json(
+                t1,
+                toleration_json=[
+                    {
+                        "key": "key1",
+                        "operator": "Equal",
+                        "value": "value1",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "key": "key2",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    }
+                ],
+            )
+
+        assert json_format.MessageToDict(my_pipeline.platform_spec) == {
+            'platforms': {
+                'kubernetes': {
+                    'deploymentSpec': {
+                        'executors': {
+                            'exec-comp': {
+                                'tolerations': [
+                                    {
+                                        'tolerationJson': {
+                                            'componentInputParameter': 'toleration_input'
+                                        }
+                                    },
+                                    {
+                                        'key': 'key3',
+                                        'operator': 'Equal',
+                                        'value': 'value3',
+                                        'effect': 'NoSchedule',
+                                    },
+                                    {
+                                        'key': 'key1',
+                                        'operator': 'Equal',
+                                        'value': 'value1',
+                                        'effect': 'NoSchedule',
+                                    },
+                                    {
+                                        'key': 'key2',
+                                        'operator': 'Exists',
+                                        'effect': 'NoExecute',
+                                    },
+                                ]
+                            },
+                        }
+                    }
+                }
+            }
+        }
+
     def test_component_upstream_input_one(self):
         # checks that upstream task input parameters
         # are supported

--- a/test/frontend-integration-test/Dockerfile
+++ b/test/frontend-integration-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/ml-pipeline-test/selenium-standalone-chrome-gcloud-nodejs:v20230322-2.0.0b11-144-g87e1c5fcf-dirty-2ca4f7
+FROM ghcr.io/kubeflow/kfp-selenium-standalone-chrome-gcloud-nodejs:main-e21bbbaf225dc0d5470df55d6d7254b7e2dd066c
 #To build this image: cd selenium-standalone-chrome-gcloud-nodejs.Docker && make push
 
 COPY --chown=seluser . /src

--- a/test/frontend-integration-test/selenium-standalone-chrome-gcloud-nodejs.Docker/README.md
+++ b/test/frontend-integration-test/selenium-standalone-chrome-gcloud-nodejs.Docker/README.md
@@ -1,0 +1,8 @@
+### Build and Push this image to KFP GHCR
+
+1. Login to GHCR container registry: `echo "<PAT>" | docker login ghcr.io -u <USERNAME> --password-stdin`
+    * Replace `<PAT>` with a GitHub Personal Access Token (PAT) with the write:packages and `read:packages` scopes, as well as `delete:packages` if needed.
+1. Set `TAG=` to `main-<commit-hash>` where `<commit-hash>` is the commit used to build the image on (your current HEAD)/
+1. Update the [Dockerfile](`./Dockerfile`) and build the image by running `docker build -t ghcr.io/kubeflow/kfp-selenium-standalone-chrome-gcloud-nodejs:$TAG .`
+1. Push the new container by running `docker push ghcr.io/kubeflow/kfp-selenium-standalone-chrome-gcloud-nodejs:$TAG`.
+1. Update the version in front end integration [Dockerfile](test/frontend-integration-test/Dockerfile) to point to your new image.


### PR DESCRIPTION
**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

## Summary by Sourcery

Introduce support for specifying multiple Kubernetes tolerations via a list input parameter.

Enhancements:
- Extend `add_toleration_json` to accept a list of tolerations via the `toleration_json` parameter.
- Implement backend logic to parse and apply lists of tolerations passed as input parameters.

Build:
- Update frontend integration test base image source to GHCR.
- Add build instructions for the test base image.

Tests:
- Add backend and Python SDK tests for list-based toleration inputs.