### PR TITLE
UPSTREAM: <carry>: Add support for optional prebuilt Go binaries in Dockerfiles

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,7 +19,8 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.23 as builder
 
 USER root
 
-RUN dnf install -y cmake clang openssl
+RUN dnf install -y cmake clang openssl \
+    && dnf clean all
 
 COPY ${SOURCE_CODE}/go.mod ./
 COPY ${SOURCE_CODE}/go.sum ./
@@ -38,8 +39,7 @@ RUN if [ "$PREBUILT_BINARY" = "unset" ]; then \
       GO111MODULE=on CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -o /bin/apiserver ./backend/src/apiserver/ ;\
     else \
       cp "${PREBUILT_BINARY}" /bin/apiserver ;\
-    fi \
-    && dnf clean all
+    fi
 
 # 2. Compile preloaded pipeline samples
 FROM registry.access.redhat.com/ubi9/python-39:9.5 as compiler

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,8 +31,15 @@ RUN GO111MODULE=on go mod download
 # Copy the source
 COPY ${SOURCE_CODE}/ ./
 
-RUN GO111MODULE=on CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -o /bin/apiserver ./backend/src/apiserver/ && \
-    dnf clean all
+# Accept an optional prebuilt Go binary
+ARG PREBUILT_BINARY=unset
+
+RUN if [ "$PREBUILT_BINARY" = "unset" ]; then \
+      GO111MODULE=on CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -o /bin/apiserver ./backend/src/apiserver/ ;\
+    else \
+      cp "${PREBUILT_BINARY}" /bin/apiserver ;\
+    fi \
+    && dnf clean all
 
 # 2. Compile preloaded pipeline samples
 FROM registry.access.redhat.com/ubi9/python-39:9.5 as compiler

--- a/backend/Dockerfile.driver
+++ b/backend/Dockerfile.driver
@@ -34,7 +34,14 @@ RUN GO111MODULE=on go mod download
 # Copy the source
 COPY ${SOURCE_CODE}/ ./
 
-RUN GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GOEXPERIMENT=strictfipsruntime go build -tags 'netgo strictfipsruntime' -o /bin/driver ./backend/src/v2/cmd/driver/*.go
+ARG PREBUILT_BINARY=unset
+
+# If PREBUILT_BINARY is set, use it; otherwise, build from source
+RUN if [ "$PREBUILT_BINARY" = "unset" ]; then \
+      GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GOEXPERIMENT=strictfipsruntime go build -tags 'netgo strictfipsruntime' -o /bin/driver ./backend/src/v2/cmd/driver/*.go; \
+    else \
+      cp ${PREBUILT_BINARY} /bin/driver; \
+    fi
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 

--- a/backend/Dockerfile.launcher
+++ b/backend/Dockerfile.launcher
@@ -36,8 +36,16 @@ RUN GO111MODULE=on go mod download
 # Copy the source
 COPY ${SOURCE_CODE}/ ./
 
-RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags netgo -ldflags '-extldflags "-static"' -o /bin/launcher-v2 ./backend/src/v2/cmd/launcher-v2/*.go
-RUN GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GOEXPERIMENT=strictfipsruntime go build -tags 'netgo strictfipsruntime' -o /bin/launcher-v2-fips ./backend/src/v2/cmd/launcher-v2/*.go
+# Accept an optional prebuilt Go binary
+ARG PREBUILT_BINARY=unset
+
+RUN if [ "$PREBUILT_BINARY" = "unset" ]; then \
+      GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags netgo -ldflags '-extldflags "-static"' -o /bin/launcher-v2 ./backend/src/v2/cmd/launcher-v2/*.go && \
+      GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GOEXPERIMENT=strictfipsruntime go build -tags 'netgo strictfipsruntime' -o /bin/launcher-v2-fips ./backend/src/v2/cmd/launcher-v2/*.go ;\
+    else \
+      cp "${PREBUILT_BINARY}" /bin/launcher-v2 && \
+      cp "${PREBUILT_BINARY}" /bin/launcher-v2-fips ;\
+    fi
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 

--- a/backend/Dockerfile.persistenceagent
+++ b/backend/Dockerfile.persistenceagent
@@ -35,7 +35,15 @@ RUN GO111MODULE=on go mod download
 # Copy the source
 COPY ${SOURCE_CODE}/ ./
 
-RUN GO111MODULE=on CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -o /bin/persistence_agent backend/src/agent/persistence/*.go
+# Accept an optional prebuilt Go binary
+ARG PREBUILT_BINARY=unset
+
+# If PREBUILT_BINARY is set, use it; otherwise, build from source
+RUN if [ "$PREBUILT_BINARY" = "unset" ]; then \
+      GO111MODULE=on CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -o /bin/persistence_agent backend/src/agent/persistence/*.go; \
+    else \
+      cp ${PREBUILT_BINARY} /bin/persistence_agent; \
+    fi
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 WORKDIR /bin

--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -40,7 +40,15 @@ RUN GO111MODULE=on go mod download
 # Copy the source
 COPY ${SOURCE_CODE}/ ./
 
-RUN GO111MODULE=on CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -o /bin/controller backend/src/crd/controller/scheduledworkflow/*.go
+# Accept an optional prebuilt Go binary
+ARG PREBUILT_BINARY=unset
+
+# If PREBUILT_BINARY is set, use it; otherwise, build from source
+RUN if [ "$PREBUILT_BINARY" = "unset" ]; then \
+      GO111MODULE=on CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -o /bin/controller backend/src/crd/controller/scheduledworkflow/*.go; \
+    else \
+      cp ${PREBUILT_BINARY} /bin/controller; \
+    fi
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 WORKDIR /bin


### PR DESCRIPTION
**Description of your changes:**
This commit adds support for optional prebuilt Go binaries in Dockerfiles using a `PREBUILT_BINARY` argument. It allows developers to skip source builds and use prebuilt binaries, serving as a workaround for issues like cross-platform builds. The default behavior remains unchanged for compatibility.

For example, one can build the binary with:

```shell
CC=x86_64-unknown-linux-gnu-gcc GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o controller backend/src/crd/controller/scheduledworkflow/*.go
```

Then build the Docker image using the prebuilt binary:

```shell
docker build --platform linux/amd64 --build-arg PREBUILT_BINARY=controller -t "dsp-scheduled-workflow:latest" -f backend/Dockerfile.scheduledworkflow .
```

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced Docker build process for backend components to support using either prebuilt binaries or building from source, providing greater flexibility during image creation. This affects the apiserver, driver, launcher, persistence agent, and scheduled workflow controller images. No changes to runtime features or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->