### PR TITLE
(feat): Update dockerfile to support multi-arch builds

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -36,6 +36,9 @@ RUN GO111MODULE=on CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -tags s
 
 # 2. Compile preloaded pipeline samples
 FROM registry.access.redhat.com/ubi9/python-39:9.5 AS compiler
+
+ARG TARGETOS TARGETARCH
+
 USER root
 RUN dnf install -y python3-setuptools jq
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
@@ -44,10 +47,10 @@ RUN python3 -m pip install -r requirements.txt --no-cache-dir
 
 # Downloading Argo CLI so that the samples are validated
 ENV ARGO_VERSION=v3.5.14
-RUN curl -sLO https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-amd64.gz && \
-    gunzip argo-linux-amd64.gz && \
-    chmod +x argo-linux-amd64 && \
-    mv ./argo-linux-amd64 /usr/local/bin/argo
+RUN curl -sLO https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-${TARGETOS:-linux}-${TARGETARCH:-amd64}.gz && \
+    gunzip argo-${TARGETOS:-linux}-${TARGETARCH:-amd64}.gz && \
+    chmod +x argo-${TARGETOS:-linux}-${TARGETARCH:-amd64} && \
+    mv ./argo-${TARGETOS:-linux}-${TARGETARCH:-amd64} /usr/local/bin/argo
 
 WORKDIR /
 COPY ./samples /samples

--- a/backend/Dockerfile.driver
+++ b/backend/Dockerfile.driver
@@ -20,6 +20,7 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.23 AS builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE
+ARG TARGETARCH
 
 ## Switch to root as required for some operations
 USER root
@@ -34,7 +35,7 @@ RUN GO111MODULE=on go mod download
 # Copy the source
 COPY ${SOURCE_CODE}/ ./
 
-RUN GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GOEXPERIMENT=strictfipsruntime go build -tags 'netgo strictfipsruntime' -o /bin/driver ./backend/src/v2/cmd/driver/*.go
+RUN GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOARCH=${TARGETARCH:-amd64} GOEXPERIMENT=strictfipsruntime go build -tags 'netgo strictfipsruntime' -o /bin/driver ./backend/src/v2/cmd/driver/*.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 

--- a/backend/Dockerfile.launcher
+++ b/backend/Dockerfile.launcher
@@ -22,6 +22,7 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.23 AS builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE
+ARG TARGETARCH
 
 ## Switch to root as required for some operations
 USER root
@@ -36,8 +37,8 @@ RUN GO111MODULE=on go mod download
 # Copy the source
 COPY ${SOURCE_CODE}/ ./
 
-RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags netgo -ldflags '-extldflags "-static"' -o /bin/launcher-v2 ./backend/src/v2/cmd/launcher-v2/*.go
-RUN GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GOEXPERIMENT=strictfipsruntime go build -tags 'netgo strictfipsruntime' -o /bin/launcher-v2-fips ./backend/src/v2/cmd/launcher-v2/*.go
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} go build -tags netgo -ldflags '-extldflags "-static"' -o /bin/launcher-v2 ./backend/src/v2/cmd/launcher-v2/*.go
+RUN GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOARCH=${TARGETARCH:-amd64} GOEXPERIMENT=strictfipsruntime go build -tags 'netgo strictfipsruntime' -o /bin/launcher-v2-fips ./backend/src/v2/cmd/launcher-v2/*.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 


### PR DESCRIPTION
**Description of your changes:**
In order to support the multi-arch builds in konflux, we need to do some modifications to the existing Dockerfiles.
The following are the JIRAs created for each dockerfile:
 - https://issues.redhat.com/browse/RHOAIENG-28735
 - https://issues.redhat.com/browse/RHOAIENG-28736
 - https://issues.redhat.com/browse/RHOAIENG-28737
 
 The builds were tested as a PoC [here](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/open-data-hub-tenant/applications/odh-multi-arch-poc/commit/13146ab2d9e8f831aee51215f3368de8958afba6)

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build process to support multiple architectures by introducing build arguments for target OS and architecture.
  * Docker images for backend components can now be built for different platforms, improving compatibility and flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->