### PR TITLE
docs(KEP): Splitting Native K8s tests for FIPS and ODH cluster out of KFP PR

### DIFF
--- a/proposals/11551-kubernetes-native-api/TestPlan-ODH.md
+++ b/proposals/11551-kubernetes-native-api/TestPlan-ODH.md
@@ -1,0 +1,31 @@
+## Feature Summary
+Please refer [this](https://github.com/kubeflow/pipelines/blob/master/proposals/11551-kubernetes-native-api/README.md) for more details
+
+## Test Sections
+
+### Cluster Config (with FIPS)
+| **Test Case**                                                                     | **Test Steps**                                        | **Expected Result**                                                                                 |
+|-----------------------------------------------------------------------------------|-------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+| (K8s mode) Create pipeline and a pipeline version using CRs                       | Match the pipeline and pipeline version (DB vs K8s)   | Pipeline and Pipeline version creation should be successful                                         |
+| (K8s mode) Create pipeline and 2 pipeline versions with same spec using CRs       | Match the pipeline and pipeline versions (DB vs K8s)  | Pipeline and Pipeline versions creation should be successful                                        |
+| (K8s mode) Create pipeline and 2 pipeline versions with different specs using CRs | Match the pipelines and pipeline versions (DB vs K8s) | Pipeline and Pipeline versions creation should be successful                                        |
+| (K8s mode) Create pipeline run                                                    | Get Run details and validate                          | Pipeline run should succeed                                                                         |
+| (K8s mode) Create an experiment and a pipeline run                                | Get Experiment and Run details and validate           | Pipeline run should be correctly associated to the created experiment and run should be successful  |
+
+### Cluster Config (in ODH)
+| **Test Case**                                                                     | **Test Steps**                                        | **Expected Result**                                                                                |
+|-----------------------------------------------------------------------------------|-------------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| (K8s mode) Create pipeline and a pipeline version using CRs                       | Match the pipeline and pipeline version (DB vs K8s)   | Pipeline and Pipeline version creation should be successful                                        |
+| (K8s mode) Create pipeline and 2 pipeline versions with same spec using CRs       | Match the pipeline and pipeline versions (DB vs K8s)  | Pipeline and Pipeline versions creation should be successful                                       |
+| (K8s mode) Create pipeline and 2 pipeline versions with different specs using CRs | Match the pipelines and pipeline versions (DB vs K8s) | Pipeline and Pipeline versions creation should be successful                                       |
+| (K8s mode) Create pipeline run                                                    | Get Run details and validate                          | Pipeline run should succeed                                                                        |
+| (K8s mode) Create an experiment and a pipeline run                                | Get Experiment and Run details and validate           | Pipeline run should be correctly associated to the created experiment and run should be successful |
+
+### Cluster Config (Disconnected RHOAI)
+| **Test Case**                                                                     | **Test Steps**                                        | **Expected Result**                                                                                |
+|-----------------------------------------------------------------------------------|-------------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| (K8s mode) Create pipeline and a pipeline version using CRs                       | Match the pipeline and pipeline version (DB vs K8s)   | Pipeline and Pipeline version creation should be successful                                        |
+| (K8s mode) Create pipeline and 2 pipeline versions with same spec using CRs       | Match the pipeline and pipeline versions (DB vs K8s)  | Pipeline and Pipeline versions creation should be successful                                       |
+| (K8s mode) Create pipeline and 2 pipeline versions with different specs using CRs | Match the pipelines and pipeline versions (DB vs K8s) | Pipeline and Pipeline versions creation should be successful                                       |
+| (K8s mode) Create pipeline run                                                    | Get Run details and validate                          | Pipeline run should succeed                                                                        |
+| (K8s mode) Create an experiment and a pipeline run                                | Get Experiment and Run details and validate           | Pipeline run should be correctly associated to the created experiment and run should be successful |


### PR DESCRIPTION
Splitting Native K8s tests for FIPS and ODH cluster out of KFP PR


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive test plan outlining validation steps for the Kubernetes Native API feature across multiple cluster configurations, including pipeline creation and execution verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->