### PR TITLE
Cherry pick Kubernetes native API fixes

### DIFF
--- a/backend/src/apiserver/filter/filter_test.go
+++ b/backend/src/apiserver/filter/filter_test.go
@@ -25,6 +25,7 @@ import (
 	apiv1beta1 "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
 	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	v2beta1crd "github.com/kubeflow/pipelines/backend/src/crd/kubernetes/v2beta1"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/testing/protocmp"
 )
@@ -640,6 +641,288 @@ func TestUnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestFilterK8sPipelines_EQ_NEQ(t *testing.T) {
+	// Build a simple Kubernetes Pipeline object
+	k8sPipeline := v2beta1crd.Pipeline{}
+	k8sPipeline.Name = "my-pipeline"
+	k8sPipeline.Spec.DisplayName = "Display"
+	k8sPipeline.Namespace = "ns1"
+
+	// EQ against pipelines.Name
+	eqFilter := &Filter{eq: map[string][]interface{}{"pipelines.Name": {"my-pipeline"}}}
+	found, err := eqFilter.FilterK8sPipelines(k8sPipeline)
+	if err != nil {
+		t.Fatalf("unexpected error for EQ: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected EQ filter to match")
+	}
+
+	// NEQ against pipelines.Name with different value (no NEQ values match actual field)
+	neqFilter := &Filter{neq: map[string][]interface{}{"pipelines.Name": {"other"}}}
+	found, err = neqFilter.FilterK8sPipelines(k8sPipeline)
+	if err != nil {
+		t.Fatalf("unexpected error for NEQ: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected NEQ filter to match when value differs")
+	}
+
+	// NEQ should not match when equal (the field equals one of the NEQ values)
+	neqNoMatch := &Filter{neq: map[string][]interface{}{"pipelines.Name": {"my-pipeline"}}}
+	found, err = neqNoMatch.FilterK8sPipelines(k8sPipeline)
+	if err != nil {
+		t.Fatalf("unexpected error for NEQ equal case: %v", err)
+	}
+	if found {
+		t.Fatalf("expected NEQ filter not to match when value equals")
+	}
+
+	// EQ should not match when not equal
+	eqNoMatch := &Filter{eq: map[string][]interface{}{"pipelines.Name": {"other"}}}
+	found, err = eqNoMatch.FilterK8sPipelines(k8sPipeline)
+	if err != nil {
+		t.Fatalf("unexpected error for EQ unequal case: %v", err)
+	}
+	if found {
+		t.Fatalf("expected EQ filter not to match when value differs")
+	}
+	// NEQ with multiple values: should match only if field is not equal to any provided
+	neqMulti := &Filter{neq: map[string][]interface{}{"pipelines.Name": {"x", "y"}}}
+	found, err = neqMulti.FilterK8sPipelines(k8sPipeline)
+	if err != nil {
+		t.Fatalf("unexpected error for NEQ multi: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected NEQ multi to match when none equal")
+	}
+
+	// NEQ multi where one equals should not match
+	neqMultiNo := &Filter{neq: map[string][]interface{}{"pipelines.Name": {"x", "my-pipeline"}}}
+	found, err = neqMultiNo.FilterK8sPipelines(k8sPipeline)
+	if err != nil {
+		t.Fatalf("unexpected error for NEQ multi equal case: %v", err)
+	}
+	if found {
+		t.Fatalf("expected NEQ multi not to match when one equals")
+	}
+
+	// AND parity across keys: both predicates must hold
+	andFilter := &Filter{
+		eq:  map[string][]interface{}{"pipelines.Name": {"my-pipeline"}},
+		neq: map[string][]interface{}{"pipelines.namespace": {"other-ns"}},
+	}
+	found, err = andFilter.FilterK8sPipelines(k8sPipeline)
+	if err != nil {
+		t.Fatalf("unexpected error for AND filter: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected AND filter to match when both predicates hold")
+	}
+
+	andFail := &Filter{
+		eq:  map[string][]interface{}{"pipelines.Name": {"my-pipeline"}},
+		neq: map[string][]interface{}{"pipelines.namespace": {"ns1"}},
+	}
+	found, err = andFail.FilterK8sPipelines(k8sPipeline)
+	if err != nil {
+		t.Fatalf("unexpected error for AND fail: %v", err)
+	}
+	if found {
+		t.Fatalf("expected AND filter not to match when one predicate fails")
+	}
+}
+
+func TestFilterK8sPipelines_IN(t *testing.T) {
+	k8sPipeline := v2beta1crd.Pipeline{}
+	k8sPipeline.Name = "my-pipeline"
+	k8sPipeline.Namespace = "ns1"
+
+	// IN with string list should match
+	inFilter := &Filter{in: map[string][]interface{}{"pipelines.Name": {[]string{"a", "my-pipeline", "b"}}}}
+	found, err := inFilter.FilterK8sPipelines(k8sPipeline)
+	if err != nil {
+		t.Fatalf("unexpected error for IN: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected IN filter to match when value in list")
+	}
+
+	// IN with non-matching list should not match
+	inNo := &Filter{in: map[string][]interface{}{"pipelines.Name": {[]string{"x", "y"}}}}
+	found, err = inNo.FilterK8sPipelines(k8sPipeline)
+	if err != nil {
+		t.Fatalf("unexpected error for IN non-match: %v", err)
+	}
+	if found {
+		t.Fatalf("expected IN filter not to match when value not in list")
+	}
+
+	// IN with multiple lists (AND semantics across lists): must be in all lists -> impossible here
+	inMulti := &Filter{in: map[string][]interface{}{"pipelines.Name": {[]string{"my-pipeline"}, []string{"x"}}}}
+	found, err = inMulti.FilterK8sPipelines(k8sPipeline)
+	if err != nil {
+		t.Fatalf("unexpected error for IN multi: %v", err)
+	}
+	if found {
+		t.Fatalf("expected IN multi not to match when not in all lists")
+	}
+
+	// IN with multiple lists where value is in all lists should match
+	inMultiOK := &Filter{in: map[string][]interface{}{"pipelines.Name": {[]string{"a", "my-pipeline"}, []string{"my-pipeline", "b"}}}}
+	found, err = inMultiOK.FilterK8sPipelines(k8sPipeline)
+	if err != nil {
+		t.Fatalf("unexpected error for IN multi ok: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected IN multi to match when present in all lists")
+	}
+}
+
+func TestFilterK8sPipelines_SUBSTRING(t *testing.T) {
+	k8sPipeline := v2beta1crd.Pipeline{}
+	k8sPipeline.Name = "my-pipeline"
+	k8sPipeline.Spec.DisplayName = "My Display"
+
+	// All substrings must be present
+	subOK := &Filter{substring: map[string][]interface{}{"pipelines.Name": {"my", "pipe"}}}
+	found, err := subOK.FilterK8sPipelines(k8sPipeline)
+	if err != nil {
+		t.Fatalf("unexpected error for substring ok: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected substring filter to match when all substrings present")
+	}
+
+	// One substring missing -> no match
+	subNo := &Filter{substring: map[string][]interface{}{"pipelines.Name": {"my", "zzz"}}}
+	found, err = subNo.FilterK8sPipelines(k8sPipeline)
+	if err != nil {
+		t.Fatalf("unexpected error for substring no: %v", err)
+	}
+	if found {
+		t.Fatalf("expected substring filter not to match when a substring missing")
+	}
+}
+
+func TestFilterK8sPipelines_UnsupportedOps(t *testing.T) {
+	k8sPipeline := v2beta1crd.Pipeline{}
+	k8sPipeline.Name = "p"
+	// Using gt should return an error
+	f := &Filter{gt: map[string][]interface{}{"pipelines.Name": {"x"}}}
+	_, err := f.FilterK8sPipelines(k8sPipeline)
+	if err == nil {
+		t.Fatalf("expected error for unsupported gt operator in K8s filter")
+	}
+}
+
+func TestFilterK8sPipelineVersions_EQ_NEQ_IN(t *testing.T) {
+	// Build a simple Kubernetes PipelineVersion object
+	k8sPv := v2beta1crd.PipelineVersion{}
+	k8sPv.Name = "v1"
+	k8sPv.Spec.DisplayName = "Version One"
+	k8sPv.Namespace = "ns1"
+
+	// EQ on name
+	eq := &Filter{eq: map[string][]interface{}{"pipeline_versions.Name": {"v1"}}}
+	found, err := eq.FilterK8sPipelineVersions(k8sPv)
+	if err != nil {
+		t.Fatalf("unexpected error EQ: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected EQ to match for versions")
+	}
+
+	// NEQ non-matching
+	neq := &Filter{neq: map[string][]interface{}{"pipeline_versions.Name": {"other"}}}
+	found, err = neq.FilterK8sPipelineVersions(k8sPv)
+	if err != nil {
+		t.Fatalf("unexpected error NEQ: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected NEQ to match when not equal for versions")
+	}
+
+	// NEQ equal should fail
+	neqFail := &Filter{neq: map[string][]interface{}{"pipeline_versions.Name": {"v1"}}}
+	found, err = neqFail.FilterK8sPipelineVersions(k8sPv)
+	if err != nil {
+		t.Fatalf("unexpected error NEQ equal: %v", err)
+	}
+	if found {
+		t.Fatalf("expected NEQ not to match when equal for versions")
+	}
+
+	// IN match
+	inMatch := &Filter{in: map[string][]interface{}{"pipeline_versions.Name": {[]string{"a", "v1"}}}}
+	found, err = inMatch.FilterK8sPipelineVersions(k8sPv)
+	if err != nil {
+		t.Fatalf("unexpected error IN match: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected IN to match for versions")
+	}
+
+	// IN non-match
+	inNo := &Filter{in: map[string][]interface{}{"pipeline_versions.Name": {[]string{"x", "y"}}}}
+	found, err = inNo.FilterK8sPipelineVersions(k8sPv)
+	if err != nil {
+		t.Fatalf("unexpected error IN non-match: %v", err)
+	}
+	if found {
+		t.Fatalf("expected IN not to match for versions when not in list")
+	}
+
+	// IN with two lists requires membership in both (AND semantics across lists) -> should fail
+	inMulti := &Filter{in: map[string][]interface{}{"pipeline_versions.Name": {[]string{"v1"}, []string{"z"}}}}
+	found, err = inMulti.FilterK8sPipelineVersions(k8sPv)
+	if err != nil {
+		t.Fatalf("unexpected error IN multi: %v", err)
+	}
+	if found {
+		t.Fatalf("expected IN multi not to match when not in all lists for versions")
+	}
+
+	// IN with two lists where both contain value -> should match
+	inMultiOK := &Filter{in: map[string][]interface{}{"pipeline_versions.Name": {[]string{"v1", "x"}, []string{"y", "v1"}}}}
+	found, err = inMultiOK.FilterK8sPipelineVersions(k8sPv)
+	if err != nil {
+		t.Fatalf("unexpected error IN multi ok for versions: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected IN multi ok to match when present in all lists for versions")
+	}
+}
+
+func TestFilterK8sPipelineVersions_SUBSTRING_AND(t *testing.T) {
+	k8sPv := v2beta1crd.PipelineVersion{}
+	k8sPv.Name = "v1"
+	k8sPv.Spec.DisplayName = "Version One"
+
+	// Substring on display name
+	subOK := &Filter{substring: map[string][]interface{}{"pipeline_versions.DisplayName": {"Version", "One"}}}
+	found, err := subOK.FilterK8sPipelineVersions(k8sPv)
+	if err != nil {
+		t.Fatalf("unexpected error substring versions ok: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected substring to match on versions display name")
+	}
+
+	// AND across keys: EQ name and substring display name
+	andFilter := &Filter{
+		eq:        map[string][]interface{}{"pipeline_versions.Name": {"v1"}},
+		substring: map[string][]interface{}{"pipeline_versions.DisplayName": {"Version"}},
+	}
+	found, err = andFilter.FilterK8sPipelineVersions(k8sPv)
+	if err != nil {
+		t.Fatalf("unexpected error versions AND: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected versions AND filter to match")
+	}
+}
+
 func TestNewWithKeyMap(t *testing.T) {
 	filterProto := &apiv1beta1.Filter{
 		Predicates: []*apiv1beta1.Predicate{
@@ -693,13 +976,13 @@ func TestFilter_ReplaceKeys(t *testing.T) {
 				in: argIN,
 			},
 			map[string]string{
-				"id":           "UUID",
-				"pipeline_id":  "UUID",
-				"name":         "Name",
-				"display_name": "Name",
-				"created_at":   "CreatedAtInSec",
-				"description":  "Description",
-				"namespace":    "Namespace",
+				"id":          "UUID",
+				"pipeline_id": "UUID",
+				"name":        "Name",
+				"DisplayName": "DisplayName",
+				"created_at":  "CreatedAtInSec",
+				"description": "Description",
+				"namespace":   "Namespace",
 			},
 			"pipelines",
 			&Filter{

--- a/backend/src/apiserver/webhook/pipelineversion_webhook.go
+++ b/backend/src/apiserver/webhook/pipelineversion_webhook.go
@@ -155,7 +155,13 @@ func (p *PipelineVersionsWebhook) Default(ctx context.Context, obj runtime.Objec
 
 	// Labels for efficient querying
 	pipelineVersion.Labels["pipelines.kubeflow.org/pipeline-id"] = string(pipeline.UID)
-	pipelineVersion.Labels["pipelines.kubeflow.org/pipeline"] = pipeline.Name
+
+	name := pipeline.Name
+	if len(name) > 63 {
+		name = name[:63]
+	}
+
+	pipelineVersion.Labels["pipelines.kubeflow.org/pipeline"] = name
 
 	trueVal := true
 

--- a/backend/src/apiserver/webhook/pipelineversion_webhook_test.go
+++ b/backend/src/apiserver/webhook/pipelineversion_webhook_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/kubeflow/pipelines/backend/src/crd/kubernetes/v2beta1"
 	k8sapi "github.com/kubeflow/pipelines/backend/src/crd/kubernetes/v2beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -223,7 +222,7 @@ func TestPipelineVersionWebhook_MutatingUpdate_FixesOwnersRef(t *testing.T) {
 			Labels:     map[string]string{"version": "v2"},
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: v2beta1.GroupVersion.String(),
+					APIVersion: k8sapi.GroupVersion.String(),
 					Kind:       "Pipeline",
 					Name:       "test-pipeline2",
 					UID:        badUID,
@@ -292,4 +291,43 @@ func TestPipelineVersionWebhook_ValidateCreate_WithPlatformSpec(t *testing.T) {
 	}
 	_, err := pipelineWebhook.ValidateCreate(context.TODO(), pipelineVersion)
 	assert.NoError(t, err, "Expected no error for a valid PipelineVersion with platform spec")
+}
+
+func TestPipelineVersionWebhook_Default_TruncatesLongPipelineNameLabel(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, k8sapi.AddToScheme(scheme))
+
+	longName := "pipeline-name-0123456789012345678901234567890123456789012345678901234567890"
+	expectedTrunc := longName[:63]
+
+	fakeClient := k8sfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&k8sapi.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      longName,
+				Namespace: "default",
+				UID:       uuid.NewUUID(),
+			},
+		}).Build()
+
+	webhook := &PipelineVersionsWebhook{Client: fakeClient, ClientNoCache: fakeClient}
+
+	pipelineVersion := &k8sapi.PipelineVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipeline-v1",
+			Namespace: "default",
+		},
+		Spec: k8sapi.PipelineVersionSpec{
+			PipelineName: longName,
+			PipelineSpec: k8sapi.IRSpec{
+				Value: json.RawMessage("{}"),
+			},
+		},
+	}
+
+	require.NoError(t, webhook.Default(context.TODO(), pipelineVersion))
+
+	got, ok := pipelineVersion.Labels["pipelines.kubeflow.org/pipeline"]
+	require.True(t, ok, "expected pipeline label to be set")
+	assert.Equal(t, expectedTrunc, got)
 }

--- a/backend/src/crd/kubernetes/v2beta1/pipeline_types.go
+++ b/backend/src/crd/kubernetes/v2beta1/pipeline_types.go
@@ -82,22 +82,24 @@ func (p *Pipeline) ToModel() *model.Pipeline {
 
 func (p *Pipeline) GetField(name string) interface{} {
 	switch name {
-	case "pipelines.id":
+	case "pipelines.UUID":
 		return p.UID
 	case "pipelines.pipeline_id":
 		return p.UID
 	case "pipelines.Name":
 		return p.Name
-	case "pipelines.display_name":
+	case "pipelines.DisplayName":
 		return p.Spec.DisplayName
-	case "pipelines.created_at":
-		return p.CreationTimestamp
-	case "description":
+	case "pipelines.CreatedAtInSec":
+		return p.CreationTimestamp.Unix()
+	case "pipelines.Description":
 		return p.Spec.Description
 	case "pipelines.namespace":
 		return p.Namespace
+	case "pipelines.Namespace":
+		return p.Namespace
 	default:
-		return ""
+		return nil
 	}
 }
 

--- a/backend/src/crd/kubernetes/v2beta1/pipelineversion_types.go
+++ b/backend/src/crd/kubernetes/v2beta1/pipelineversion_types.go
@@ -287,15 +287,26 @@ func (p *PipelineVersion) GetField(name string) interface{} {
 	case "pipeline_versions.UUID":
 		return p.UID
 	case "pipeline_versions.pipeline_version_id":
-		return p.OwnerReferences[0].UID
+		return p.UID
 	case "pipeline_versions.Name":
 		return p.Name
+	case "pipeline_versions.Status":
+		if len(p.Status.Conditions) > 0 {
+			return p.Status.Conditions[0].Reason
+		}
+		return nil
 	case "pipeline_versions.CreatedAtInSec":
-		return p.CreationTimestamp
+		return p.CreationTimestamp.Unix()
 	case "pipeline_versions.DisplayName":
 		return p.Spec.DisplayName
 	case "pipeline_versions.Description":
 		return p.Spec.Description
+	case "pipeline_versions.PipelineSpec":
+		return p.Spec.PipelineSpec
+	case "pipeline_versions.CodeSourceUrl":
+		return p.Spec.CodeSourceURL
+	case "pipeline_versions.PipelineSpecURI":
+		return p.Spec.PipelineSpecURI
 	default:
 		return nil
 	}

--- a/backend/src/crd/kubernetes/v2beta1/pipelineversion_types.go
+++ b/backend/src/crd/kubernetes/v2beta1/pipelineversion_types.go
@@ -179,6 +179,15 @@ func (p *PipelineVersion) ToModel() (*model.PipelineVersion, error) {
 		piplineSpecAndPlatformSpec = append(piplineSpecAndPlatformSpec, platformSpecBytes...)
 	}
 
+	// The pipeline spec in model.PipelineVersion ignores platform specs that don't have a "kubernetes" platform.
+	// This additional parsing filters out platform specs that normally are excluded when the pipeline version is
+	// created through the REST API. This is done rather than modifying the mutating webhook to remove these
+	// platform specs so that GitOps tools don't see a diff from what is in Git and what is on the cluster.
+	v2Spec, err := template.NewV2SpecTemplate(piplineSpecAndPlatformSpec, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse the pipeline spec: %w", err)
+	}
+
 	pipelineVersionStatus := model.PipelineVersionCreating
 
 	for _, condition := range p.Status.Conditions {
@@ -214,7 +223,7 @@ func (p *PipelineVersion) ToModel() (*model.PipelineVersion, error) {
 		Status:          pipelineVersionStatus,
 		CodeSourceUrl:   p.Spec.CodeSourceURL,
 		Description:     p.Spec.Description,
-		PipelineSpec:    string(piplineSpecAndPlatformSpec),
+		PipelineSpec:    string(v2Spec.Bytes()),
 		PipelineSpecURI: p.Spec.PipelineSpecURI,
 	}, nil
 }


### PR DESCRIPTION
**Description of your changes:**

 Each commit message has the original commit hash.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added IN and substring filtering for pipelines and pipeline versions with consistent AND semantics; unified multi-field filter evaluation.
  * Deletions now poll briefly for confirmation to improve post-delete consistency.
* Bug Fixes
  * Corrected field mappings (UUIDs, display names, created-at seconds) and pipeline version ID source.
  * Unified filter error reporting and clarified unsupported-operator errors.
  * Truncate long pipeline name labels to 63 characters for Kubernetes compatibility.
  * Pipeline versions now exclude non‑Kubernetes platform data from emitted specs.
* Tests
  * Expanded tests for filters, CRD field access, webhook behavior, and spec processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->