### PR TITLE
Revert changes to backend/src/v2/metadata/env.go.

### DIFF
--- a/backend/metadata_writer/src/metadata_helpers.py
+++ b/backend/metadata_writer/src/metadata_helpers.py
@@ -32,8 +32,10 @@ def value_to_mlmd_value(value) -> metadata_store_pb2.Value:
 
 
 def connect_to_mlmd() -> metadata_store.MetadataStore:
-    metadata_service_host = "metadata-grpc-service.kubeflow"
-    metadata_service_port = 8080
+    metadata_service_host = os.environ.get(
+        'METADATA_GRPC_SERVICE_SERVICE_HOST', 'metadata-grpc-service')
+    metadata_service_port = int(os.environ.get(
+        'METADATA_GRPC_SERVICE_SERVICE_PORT', 8080))
 
     mlmd_connection_config = metadata_store_pb2.MetadataStoreClientConfig(
         host="[{}]".format(metadata_service_host) if isIPv6(metadata_service_host) else metadata_service_host,

--- a/backend/src/v2/metadata/env.go
+++ b/backend/src/v2/metadata/env.go
@@ -1,9 +1,6 @@
 package metadata
 
-const (
-	metadataGrpcServiceAddress = "metadata-grpc-service.kubeflow"
-	metadataGrpcServicePort    = "8080"
-)
+import "os"
 
 type ServerConfig struct {
 	Address string
@@ -11,8 +8,19 @@ type ServerConfig struct {
 }
 
 func DefaultConfig() *ServerConfig {
+	// The env vars exist when metadata-grpc-service Kubernetes service is
+	// in the same namespace as the current Pod.
+	// https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables
+	hostEnv := os.Getenv("METADATA_GRPC_SERVICE_SERVICE_HOST")
+	portEnv := os.Getenv("METADATA_GRPC_SERVICE_SERVICE_PORT")
+	if hostEnv != "" && portEnv != "" {
+		return &ServerConfig{
+			Address: hostEnv,
+			Port:    portEnv,
+		}
+	}
 	return &ServerConfig{
-		Address: metadataGrpcServiceAddress,
-		Port:    metadataGrpcServicePort,
+		Address: "metadata-grpc-service.kubeflow",
+		Port:    "8080",
 	}
 }


### PR DESCRIPTION
**Description of your changes:**
Revert the changes made to `backend/src/v2/metadata/env.go` in #11965 merged in via #210. This change, which updated the `METADATA_GRPC_SERVICE_SERVICE_HOST` and `METADATA_GRPC_SERVICE_SERVICE_PORT` environment variables to static constants with fixed values - `"metadata-grpc-service.kubeflow"` and `"8080"` respectively. While this works upstream, this change causes failure downstream, as DSPO still inputs a DSPO-specific value into this environment variable. 

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced metadata service configuration across components to read host and port from the deployment environment with sensible fallbacks, improving deployment flexibility while preserving existing default behavior and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->