### PR TITLE
ci: include building test image to build-prs workflow and remove it from …

### DIFF
--- a/.github/workflows/build-and-push-test-image.yml
+++ b/.github/workflows/build-and-push-test-image.yml
@@ -9,11 +9,6 @@ on:
       - master
       - 'v*'
       - stable
-  pull_request:
-    paths:
-      - 'backend/test/Dockerfile.test'
-      - 'backend/test/**'
-      - '.github/workflows/build-and-push-test-image.yml'
   workflow_dispatch:
     inputs:
       branch_name:

--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -80,6 +80,8 @@ jobs:
             dockerfile: backend/Dockerfile.driver
           - image: ds-pipelines-launcher
             dockerfile: backend/Dockerfile.launcher
+          - image: ds-pipelines-tests
+            dockerfile: backend/test/Dockerfile.test
     steps:
       - uses: actions/checkout@v3
       - name: Build Image
@@ -123,6 +125,7 @@ jobs:
           FULLIMG_METADATA_GRPC: quay.io/opendatahub/mlmd-grpc-server:latest
           FULLIMG_DRIVER: quay.io/${{ env.QUAY_ORG }}/ds-pipelines-driver:${{ env.TARGET_IMAGE_TAG }}
           FULLIMG_LAUNCHER: quay.io/${{ env.QUAY_ORG }}/ds-pipelines-launcher:${{ env.TARGET_IMAGE_TAG }}
+          FULLIMG_TESTS: quay.io/${{ env.QUAY_ORG }}/ds-pipelines-tests:${{ env.TARGET_IMAGE_TAG }}
         run: |
           git config user.email "${{ env.GH_USER_EMAIL }}"
           git config user.name "${{ env.GH_USER_NAME }}"
@@ -147,6 +150,7 @@ jobs:
             **MLMD Server**: `${{ env.FULLIMG_METADATA_GRPC }}`
             **MLMD Envoy Proxy**: `${{ env.FULLIMG_METADATA_ENVOY }}`
             **UI**: `${{ env.FULLIMG_FRONTEND }}`
+            **TESTS**: `${{ env.FULLIMG_TESTS }}`
           EOF
 
           gh pr comment ${{ needs.fetch-data.outputs.pr_number }} --body-file /tmp/body-file.txt
@@ -223,6 +227,7 @@ jobs:
           - ds-pipelines-driver
           - ds-pipelines-metadata-grpc
           - ds-pipelines-metadata-envoy
+          - ds-pipelines-tests
     steps:
       - name: Delete PR image
         shell: bash


### PR DESCRIPTION
…build and push test images workflow

**Description of your changes:**


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflow triggers updated to run on pushes and manual dispatch only (PR-based path-filtered triggers removed).
  * PR build pipeline enhanced to include an additional test image in build and cleanup flows, and to expose that image in PR summaries/comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->