### PR TITLE
ci: Add option to add manual label to confirm integration tests verification and fixing the condition to run add label job

### DIFF
--- a/.github/scripts/check_integration_test_label.py
+++ b/.github/scripts/check_integration_test_label.py
@@ -33,7 +33,7 @@ def post_instruction_comment(pull_request):
 This pull request is merging **main** → **stable** and requires integration test verification.
 
 ### ✅ Required Action:
-Comment `/integration-tests-ok` on this PR **only after** running the integration tests.
+Manually add label "integration-tests-verified" or comment `/integration-tests-ok` on this PR **only after** running the integration tests.
 
 ### 📝 Steps:
 
@@ -67,7 +67,7 @@ Comment `/integration-tests-ok` on this PR **only after** running the integratio
     13. Run [Iris Pipeline](https://github.com/red-hat-data-services/ods-ci/blob/master/ods_ci/tests/Resources/Files/pipeline-samples/v2/cache-disabled/iris_pipeline_compiled.yaml), [Flip Coin](https://github.com/red-hat-data-services/ods-ci/blob/master/ods_ci/tests/Resources/Files/pipeline-samples/v2/cache-disabled/flip_coin_compiled.yaml) pipelines
     14. Make sure the pipeline runs Succeeds
     15. Repeat the above steps but this time check `ENABLE_FIPS_IN_CLUSTER` checkbox to create a FIPS cluster
-2. Comment `/integration-tests-ok` on this PR to add the verification label
+2. Manually add label "integration-tests-verified" or comment `/integration-tests-ok` on this PR to add the verification label
 3. This workflow check will automatically pass once the label is added
 
 ### 🔒 Authorization:
@@ -145,10 +145,9 @@ New commits have been pushed to this PR. The `integration-tests-verified` label 
 
 **Next Steps to Pass This Check:**
 1. Re-run integration tests in OpenShift cluster with latest ODH nightly
-2. Fetch nightly build information from **#odh-nightlies-notifications** Slack channel
-3. Comment `/integration-tests-ok` on this PR after confirming tests pass with the new commits
+2. Readd the label "integration-tests-verified" or comment `/integration-tests-ok` on this PR after confirming tests pass with the new commits
 
-Once you comment `/integration-tests-ok`, the label will be re-added and this workflow will automatically pass."""
+Once you re-add the label or comment `/integration-tests-ok`, the label will be re-added and this workflow will automatically pass."""
 
                 try:
                     pull_request.create_issue_comment(removal_comment)

--- a/.github/workflows/stable-merge-check.yml
+++ b/.github/workflows/stable-merge-check.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - stable
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened, edited, labeled]
   issue_comment:
     types: [created, edited]
 
@@ -13,12 +13,33 @@ permissions:
   pull-requests: write
   contents: read
 
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   # Job to handle /integration-tests-ok command
   process-integration-command:
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/integration-tests-ok') }}
+    outputs:
+      labeled: ${{ steps.add-label.outputs.labeled }}
+    if: contains(github.event.comment.body, '/integration-tests-ok')
     steps:
+      - name: Debug Event Context
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Event action: ${{ github.event.action }}"
+          echo "Issue number: ${{ github.event.issue.number }}"
+          echo "Comment body: $COMMENT_BODY"
+          if [[ "${{ github.event.issue.pull_request }}" != "null" && "${{ github.event.issue.pull_request }}" != "" ]]; then
+            echo "PR URL: ${{ github.event.issue.pull_request.url }}"
+            echo "This is a PR comment"
+          else
+            echo "This is NOT a PR comment - exiting"
+            exit 1
+          fi
+
       - name: Check if the author is a member or Owner
         id: check-condition
         run: |
@@ -34,15 +55,12 @@ jobs:
         env:
           message: 🚫 This command cannot be processed. Only organization members or owners can use the `/integration-tests-ok` command.
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
           gh issue comment ${{ github.event.issue.number }} --repo "${{ github.repository }}" --body "${{ env.message }}"
           echo ${message}
           exit 1
 
       - name: Check if PR target
         if: env.condition_met == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_URL="${{ github.event.issue.pull_request.url }}"
           PR_DATA=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" "$PR_URL")
@@ -62,21 +80,19 @@ jobs:
       - name: Leave a Comment on Invalid Target
         if: env.condition_met == 'true' && env.valid_target == 'false'
         env:
-          message: ⚠️ This command only works for pull requests to `master/stable` branches.
+          message: ⚠️ This command only works for pull requests to `stable` branches.
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
           gh issue comment ${{ github.event.issue.number }} --repo "${{ github.repository }}" --body "${{ env.message }}"
           echo ${message}
           exit 1
 
       - name: Add integration-tests-verified label
         if: env.condition_met == 'true' && env.valid_target == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: add-label
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
           gh issue edit ${{ github.event.issue.number }} --add-label "integration-tests-verified" --repo "${{ github.repository }}"
           echo "✅ Added integration-tests-verified label"
+          echo "labeled=true" >> $GITHUB_OUTPUT
 
       - name: Leave success comment
         if: env.condition_met == 'true' && env.valid_target == 'true'
@@ -88,14 +104,42 @@ jobs:
 
             **Note**: This label will be automatically removed if new commits are pushed to ensure tests are re-run with the latest changes.
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
           gh issue comment ${{ github.event.issue.number }} --repo "${{ github.repository }}" --body "${{ env.message }}"
 
   # Job to remove label on new commits and check for label presence
   integration-test-check:
     name: Integration Test Verification
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || contains(github.event.comment.body, '/integration-tests-ok')
+    if: (github.event_name == 'pull_request' && github.event.action != 'labeled') || (github.event.action == 'labeled' && github.event.label.name == 'integration-tests-verified')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install PyGithub
+
+      - name: Check integration test label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_ACTION: ${{ github.event.action }}
+        run: |
+          python .github/scripts/check_integration_test_label.py
+
+  integration-test-check-after-label-command:
+    name: Integration Test Verification After Label
+    runs-on: ubuntu-latest
+    needs: process-integration-command
+    if: needs.process-integration-command.outputs.labeled == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
**Description of your changes:**


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated integration-test verification to allow either manually adding an "integration-tests-verified" label or commenting `/integration-tests-ok` to trigger verification.
  * Switched to a label-centric workflow: CI now responds to labeled events, re-checks after label addition, and posts clearer success/follow-up messages.
  * Removed external channel references and clarified re-enable instructions when new commits are pushed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->