### PR TITLE
test: changing e2e tests suite name to AIPipelinesE2ETests

### DIFF
--- a/backend/test/end2end/e2e_suite_test.go
+++ b/backend/test/end2end/e2e_suite_test.go
@@ -162,5 +162,5 @@ func TestAPIs(t *testing.T) {
 	reporterConfigE2E.SilenceSkips = true
 	reporterConfigE2E.JUnitReport = filepath.Join(testReportDirectory, junitReportFilename)
 	reporterConfigE2E.JSONReport = filepath.Join(testReportDirectory, jsonReportFilename)
-	RunSpecs(t, "E2ETestsSuite", suiteConfigE2E, reporterConfigE2E)
+	RunSpecs(t, "AIPipelinesE2ETests", suiteConfigE2E, reporterConfigE2E)
 }


### PR DESCRIPTION
**Description of your changes:**
Changing the e2e tests suite name so that Jenkins reports can capture the name properly, otherwise it chokes if there are special characters like spaces in the name.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [x] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite organization for improved categorization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->