### PR TITLE
ci: fixing test image docker file path in the git workflow

### DIFF
--- a/.github/workflows/build-and-push-test-image.yml
+++ b/.github/workflows/build-and-push-test-image.yml
@@ -21,7 +21,7 @@ env:
   QUAY_ID: ${{ secrets.QUAY_ROBOT_USERNAME }}
   QUAY_TOKEN: ${{ secrets.QUAY_ROBOT_TOKEN }}
   IMAGE_REPO: ds-pipelines-tests
-  DOCKERFILE_PATH: backend/test/Dockerfile.test
+  DOCKERFILE_PATH: backend/test/images/Dockerfile.test
 
 jobs:
   build-test-image:

--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -81,7 +81,7 @@ jobs:
           - image: ds-pipelines-launcher
             dockerfile: backend/Dockerfile.launcher
           - image: ds-pipelines-tests
-            dockerfile: backend/test/Dockerfile.test
+            dockerfile: backend/test/images/Dockerfile.test
     steps:
       - uses: actions/checkout@v3
       - name: Build Image


### PR DESCRIPTION
**Description of your changes:**
In this [pr](https://github.com/opendatahub-io/data-science-pipelines/pull/235), I forgot to change the path to the docker file in the github workflows

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD pipeline configuration paths for consistency and organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->