### PR TITLE
chore: Support OIDC

### DIFF
--- a/backend/test/testutil/kubernetes_utils.go
+++ b/backend/test/testutil/kubernetes_utils.go
@@ -31,6 +31,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/exec" // Register exec credential plugin for OIDC authentication
 )
 
 func CreateK8sClient() (*kubernetes.Clientset, error) {


### PR DESCRIPTION
**Description of your changes:**
This just adds an import of auth/exec to get rid of the following exception when K8s tried to use exec to create k8s client when oidc or other IDC providers are configured:
```
[38;5;243m/dspa/backend/test/end2end/e2e_suite_test.go:59[0m
[2026-01-19T16:38:38.473Z] 
[2026-01-19T16:38:38.473Z]   [38;5;9m[FAILED] Failed to initialize K8s client
[2026-01-19T16:38:38.473Z]   Expected
[2026-01-19T16:38:38.473Z]       <*errors.errorString | 0xc000c64680>: 
[2026-01-19T16:38:38.473Z]       no Auth Provider found for name "oidc"
[2026-01-19T16:38:38.473Z]       {
[2026-01-19T16:38:38.473Z]           s: "no Auth Provider found for name \"oidc\"",
[2026-01-19T16:38:38.473Z]       }
[2026-01-19T16:38:38.473Z]   to be nil[0m
[2026-01-19T16:38:38.473Z]   [38;5;9mIn [1m[BeforeSuite][0m[38;5;9m at: [1m/dspa/backend/test/end2end/e2e_suite_test.go:69[0m [38;5;243m@ 01/19/26 16:38:24.594[0m
```

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [ ] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
