### PR TITLE
chore: replace k8s credential plugin exec with oidc

### DIFF
--- a/backend/test/testutil/kubernetes_utils.go
+++ b/backend/test/testutil/kubernetes_utils.go
@@ -31,7 +31,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/exec" // Register exec credential plugin for OIDC authentication
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" // Register credential plugin for OIDC authentication
 )
 
 func CreateK8sClient() (*kubernetes.Clientset, error) {


### PR DESCRIPTION
**Description of your changes:**
Replace `k8s.io/client-go/plugin/pkg/client/auth/exec` plugin with `k8s.io/client-go/plugin/pkg/client/auth/oidc` in order to properly register the plugin.
Fixes issue in which the following error is logged during `backend/test/end2end/e2e_suite_test.go` test initialization:
```
no Auth Provider found for name "oidc"
```

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [ ] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes authentication method from exec-based to OIDC-based authentication in test utilities, improving credential handling during client initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->