### PR TITLE
UPSTREAM: <carry>: chore(config): Rename `ARGO_POD_NAME` to `KFP_POD_NAME` in pod name fetch logic

### DIFF
--- a/backend/src/v2/config/env.go
+++ b/backend/src/v2/config/env.go
@@ -104,7 +104,7 @@ func InPodNamespace() (string, error) {
 
 // InPodName gets the pod name from inside a Kubernetes Pod.
 func InPodName() (string, error) {
-	if podName, exists := os.LookupEnv("ARGO_POD_NAME"); exists && podName != "" {
+	if podName, exists := os.LookupEnv("KFP_POD_NAME"); exists && podName != "" {
 		return podName, nil
 	}
 	podName, err := os.ReadFile("/etc/hostname")


### PR DESCRIPTION
**Description of your changes:**

DSP's InPodName() reads `ARGO_POD_NAME`, but the compiler injects `KFP_POD_NAME` via downward API. The lookup never matches, so it always falls back to `/etc/hostname`, which truncates at 63 characters — breaking PVC creation for pipelines with long names.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [ ] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pod name resolution configuration to support alternative environment variable sources with maintained fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->