### PR TITLE
UPSTREAM: <carry>: feat(backend): Add support for managed pipeline manifests in LoadSamples

### DIFF
--- a/backend/src/apiserver/config/config.go
+++ b/backend/src/apiserver/config/config.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -86,6 +87,82 @@ type config struct {
 	Pipelines            []configPipelines
 }
 
+type managedPipelineManifestEntry struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Path        string `json:"path"`
+	Stability   string `json:"stability"`
+}
+
+// loadManagedPipelinesManifest reads a managed-pipelines.json manifest and
+// returns configPipelines entries for any pipeline whose name is not already
+// in the existing set. Returns nil without error when the manifest file does
+// not exist (volume not mounted / flag not set).
+func loadManagedPipelinesManifest(manifestPath string, existing map[string]bool) ([]configPipelines, error) {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read managed pipelines manifest %s: %w", manifestPath, err)
+	}
+
+	var entries []managedPipelineManifestEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("failed to parse managed pipelines manifest %s: %w", manifestPath, err)
+	}
+
+	dir := filepath.Dir(manifestPath)
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve managed pipelines directory %s: %w", dir, err)
+	}
+
+	seen := make(map[string]bool, len(entries))
+	var pipelines []configPipelines
+	for _, entry := range entries {
+		if entry.Name == "" {
+			return nil, fmt.Errorf("managed pipelines manifest %s contains entry with empty name", manifestPath)
+		}
+		if entry.Path == "" {
+			return nil, fmt.Errorf("managed pipelines manifest %s contains entry %q with empty path", manifestPath, entry.Name)
+		}
+		if seen[entry.Name] {
+			return nil, fmt.Errorf("managed pipelines manifest %s contains duplicate name %q", manifestPath, entry.Name)
+		}
+		seen[entry.Name] = true
+		if strings.ContainsAny(entry.Name, "/\\") || strings.Contains(entry.Name, "..") {
+			return nil, fmt.Errorf("managed pipeline name %q contains invalid character (/, \\, or ..)", entry.Name)
+		}
+		if existing[entry.Name] {
+			glog.Infof("Skipping managed pipeline %q: already in sample config", entry.Name)
+			continue
+		}
+		fileName := entry.Name + ".yaml"
+		filePath := filepath.Join(resolvedDir, fileName)
+		if !strings.HasPrefix(filePath, resolvedDir+string(filepath.Separator)) {
+			return nil, fmt.Errorf("managed pipeline %q: constructed path escapes directory %q", entry.Name, resolvedDir)
+		}
+		resolvedPath, evalErr := filepath.EvalSymlinks(filePath)
+		if evalErr != nil && !os.IsNotExist(evalErr) {
+			return nil, fmt.Errorf("failed to resolve path for managed pipeline %q: %w", entry.Name, evalErr)
+		}
+		if evalErr == nil {
+			rel, relErr := filepath.Rel(resolvedDir, resolvedPath)
+			if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				return nil, fmt.Errorf("managed pipeline %q: resolved path %q escapes directory %q", entry.Name, resolvedPath, resolvedDir)
+			}
+			filePath = resolvedPath
+		}
+		pipelines = append(pipelines, configPipelines{
+			Name:        entry.Name,
+			Description: entry.Description,
+			File:        filePath,
+		})
+	}
+	return pipelines, nil
+}
+
 // LoadSamples preloads a collection of pipeline samples
 //
 // If LoadSamplesOnRestart is false then Samples are only
@@ -95,7 +172,7 @@ type config struct {
 // samples. If LoadSamplesOnRestart is true then PipelineVersions
 // are uploaded if they do not already exist upon upgrade or pod
 // restart.
-func LoadSamples(resourceManager *resource.ResourceManager, sampleConfigPath string) error {
+func LoadSamples(resourceManager *resource.ResourceManager, sampleConfigPath string, managedPipelinesDir string) error {
 	pathExists, err := client.PathExists(sampleConfigPath)
 	if err != nil {
 		return err
@@ -140,6 +217,19 @@ func LoadSamples(resourceManager *resource.ResourceManager, sampleConfigPath str
 	if !pipelineConfig.LoadSamplesOnRestart && haveSamplesLoaded {
 		glog.Infof("Samples already loaded in the past. Skip loading.")
 		return nil
+	}
+
+	if managedPipelinesDir != "" {
+		existing := make(map[string]bool, len(pipelineConfig.Pipelines))
+		for _, p := range pipelineConfig.Pipelines {
+			existing[p.Name] = true
+		}
+		manifestPath := filepath.Join(managedPipelinesDir, "managed-pipelines.json")
+		managedPipelines, mergeErr := loadManagedPipelinesManifest(manifestPath, existing)
+		if mergeErr != nil {
+			return mergeErr
+		}
+		pipelineConfig.Pipelines = append(pipelineConfig.Pipelines, managedPipelines...)
 	}
 
 	tags, err := parseManagedPipelinesTags()

--- a/backend/src/apiserver/config/config.go
+++ b/backend/src/apiserver/config/config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -33,6 +34,8 @@ import (
 )
 
 const managedPipelinesUploadTagsEnv = "MANAGED_PIPELINES_UPLOAD_TAGS"
+
+var validPipelineName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
 // parseManagedPipelinesTags reads MANAGED_PIPELINES_UPLOAD_TAGS from the
 // environment and returns the parsed key=value pairs. Returns nil when the
@@ -130,8 +133,8 @@ func loadManagedPipelinesManifest(manifestPath string, existing map[string]bool)
 			return nil, fmt.Errorf("managed pipelines manifest %s contains duplicate name %q", manifestPath, entry.Name)
 		}
 		seen[entry.Name] = true
-		if strings.ContainsAny(entry.Name, "/\\") || strings.Contains(entry.Name, "..") {
-			return nil, fmt.Errorf("managed pipeline name %q contains invalid character (/, \\, or ..)", entry.Name)
+		if !validPipelineName.MatchString(entry.Name) {
+			return nil, fmt.Errorf("managed pipeline name %q is invalid: must match %s", entry.Name, validPipelineName.String())
 		}
 		if existing[entry.Name] {
 			glog.Infof("Skipping managed pipeline %q: already in sample config", entry.Name)

--- a/backend/src/apiserver/config/config.go
+++ b/backend/src/apiserver/config/config.go
@@ -138,7 +138,8 @@ func loadManagedPipelinesManifest(manifestPath string, existing map[string]bool)
 		}
 		fileName := entry.Name + ".yaml"
 		filePath := filepath.Join(resolvedDir, fileName)
-		if !strings.HasPrefix(filePath, resolvedDir+string(filepath.Separator)) {
+		rel, relErr := filepath.Rel(resolvedDir, filePath)
+		if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			return nil, fmt.Errorf("managed pipeline %q: constructed path escapes directory %q", entry.Name, resolvedDir)
 		}
 		resolvedPath, evalErr := filepath.EvalSymlinks(filePath)

--- a/backend/src/apiserver/config/config.go
+++ b/backend/src/apiserver/config/config.go
@@ -91,7 +91,6 @@ type managedPipelineManifestEntry struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Path        string `json:"path"`
-	Stability   string `json:"stability"`
 }
 
 // loadManagedPipelinesManifest reads a managed-pipelines.json manifest and

--- a/backend/src/apiserver/config/config.go
+++ b/backend/src/apiserver/config/config.go
@@ -93,7 +93,6 @@ type config struct {
 type managedPipelineManifestEntry struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	Path        string `json:"path"`
 }
 
 // loadManagedPipelinesManifest reads a managed-pipelines.json manifest and
@@ -125,9 +124,6 @@ func loadManagedPipelinesManifest(manifestPath string, existing map[string]bool)
 	for _, entry := range entries {
 		if entry.Name == "" {
 			return nil, fmt.Errorf("managed pipelines manifest %s contains entry with empty name", manifestPath)
-		}
-		if entry.Path == "" {
-			return nil, fmt.Errorf("managed pipelines manifest %s contains entry %q with empty path", manifestPath, entry.Name)
 		}
 		if seen[entry.Name] {
 			return nil, fmt.Errorf("managed pipelines manifest %s contains duplicate name %q", manifestPath, entry.Name)

--- a/backend/src/apiserver/config/config.go
+++ b/backend/src/apiserver/config/config.go
@@ -159,6 +159,9 @@ func loadManagedPipelinesManifest(manifestPath string, existing map[string]bool)
 			File:        filePath,
 		})
 	}
+	if len(pipelines) > 0 {
+		glog.Infof("Loaded %d managed pipeline(s) from %s", len(pipelines), manifestPath)
+	}
 	return pipelines, nil
 }
 

--- a/backend/src/apiserver/config/config_test.go
+++ b/backend/src/apiserver/config/config_test.go
@@ -997,7 +997,13 @@ func TestLoadManagedPipelinesManifest_InvalidNamesRejected(t *testing.T) {
 		{"traversal with slashes", "../../etc/passwd"},
 		{"forward slash", "sub/dir"},
 		{"backslash", "pipe\\line"},
-		{"dot-dot without separator", "pipe..line"},
+		{"null byte", "pipe\x00line"},
+		{"space", "my pipeline"},
+		{"control char tab", "pipe\tline"},
+		{"unicode", "pipeline-日本語"},
+		{"leading dot", ".hidden"},
+		{"leading hyphen", "-flag"},
+		{"leading underscore", "_pipeline"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1009,7 +1015,40 @@ func TestLoadManagedPipelinesManifest_InvalidNamesRejected(t *testing.T) {
 
 			_, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "invalid character")
+			assert.Contains(t, err.Error(), "invalid")
+		})
+	}
+}
+
+func TestLoadManagedPipelinesManifest_ValidNamesAccepted(t *testing.T) {
+	cases := []struct {
+		name      string
+		validName string
+	}{
+		{"lowercase with hyphens", "my-pipeline"},
+		{"lowercase with underscores", "my_pipeline"},
+		{"with dot", "pipeline.v2"},
+		{"short alphanumeric", "A1"},
+		{"single char", "x"},
+		{"leading digit", "9pipeline"},
+		{"mixed case", "MyPipeline"},
+		{"realistic name", "autorag-documents-indexing"},
+		{"realistic underscore name", "sft_pipeline"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, tc.validName+".yaml"), []byte("apiVersion: v2"), 0644))
+
+			entries := []managedPipelineManifestEntry{
+				{Name: tc.validName, Description: "valid", Path: "p.py"},
+			}
+			writeManagedPipelinesManifest(t, dir, entries)
+
+			got, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+			assert.Equal(t, tc.validName, got[0].Name)
 		})
 	}
 }

--- a/backend/src/apiserver/config/config_test.go
+++ b/backend/src/apiserver/config/config_test.go
@@ -542,8 +542,8 @@ func TestLoadManagedPipelinesManifest_HappyPath(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "pipeline-b.yaml"), []byte("apiVersion: v2"), 0644))
 
 	entries := []managedPipelineManifestEntry{
-		{Name: "pipeline-a", Description: "Pipeline A", Path: "pipelines/a/pipeline.py"},
-		{Name: "pipeline-b", Description: "Pipeline B", Path: "pipelines/b/pipeline.py"},
+		{Name: "pipeline-a", Description: "Pipeline A"},
+		{Name: "pipeline-b", Description: "Pipeline B"},
 	}
 	writeManagedPipelinesManifest(t, dir, entries)
 
@@ -573,8 +573,8 @@ func TestLoadManagedPipelinesManifest_SkipDuplicates(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "new-pipeline.yaml"), []byte("apiVersion: v2"), 0644))
 
 	entries := []managedPipelineManifestEntry{
-		{Name: "existing-pipeline", Description: "Already exists", Path: "pipelines/existing/pipeline.py"},
-		{Name: "new-pipeline", Description: "New one", Path: "pipelines/new/pipeline.py"},
+		{Name: "existing-pipeline", Description: "Already exists"},
+		{Name: "new-pipeline", Description: "New one"},
 	}
 	writeManagedPipelinesManifest(t, dir, entries)
 
@@ -597,25 +597,13 @@ func TestLoadManagedPipelinesManifest_EmptyManifest(t *testing.T) {
 func TestLoadManagedPipelinesManifest_EmptyNameRejected(t *testing.T) {
 	dir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "", Description: "No name", Path: "no-name.yaml"},
+		{Name: "", Description: "No name"},
 	}
 	writeManagedPipelinesManifest(t, dir, entries)
 
 	_, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty name")
-}
-
-func TestLoadManagedPipelinesManifest_EmptyPathRejected(t *testing.T) {
-	dir := t.TempDir()
-	entries := []managedPipelineManifestEntry{
-		{Name: "has-name", Description: "No path", Path: ""},
-	}
-	writeManagedPipelinesManifest(t, dir, entries)
-
-	_, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "empty path")
 }
 
 func TestLoadManagedPipelinesManifest_MalformedJSON(t *testing.T) {
@@ -626,38 +614,11 @@ func TestLoadManagedPipelinesManifest_MalformedJSON(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestLoadManagedPipelinesManifest_DangerousPathFieldIgnored(t *testing.T) {
-	cases := []struct {
-		name      string
-		entryName string
-		pathField string
-	}{
-		{"traversal path", "safe-name", "../escape.yaml"},
-		{"absolute path", "absolute", "/etc/passwd"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			require.NoError(t, os.WriteFile(filepath.Join(dir, tc.entryName+".yaml"), []byte("apiVersion: v2"), 0644))
-
-			entries := []managedPipelineManifestEntry{
-				{Name: tc.entryName, Description: "Path field ignored", Path: tc.pathField},
-			}
-			writeManagedPipelinesManifest(t, dir, entries)
-
-			got, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
-			require.NoError(t, err, "Path field is metadata-only; dangerous values do not affect file resolution")
-			require.Len(t, got, 1)
-			assert.Equal(t, tc.entryName+".yaml", filepath.Base(got[0].File))
-		})
-	}
-}
-
 func TestLoadManagedPipelinesManifest_DuplicateNamesRejected(t *testing.T) {
 	dir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "dup", Description: "first", Path: "a.yaml"},
-		{Name: "dup", Description: "second", Path: "b.yaml"},
+		{Name: "dup", Description: "first"},
+		{Name: "dup", Description: "second"},
 	}
 	writeManagedPipelinesManifest(t, dir, entries)
 
@@ -673,7 +634,7 @@ func TestLoadManagedPipelinesManifest_SymlinkEscapeRejected(t *testing.T) {
 	require.NoError(t, os.Symlink(outside, filepath.Join(dir, "symlink-escape.yaml")))
 
 	entries := []managedPipelineManifestEntry{
-		{Name: "symlink-escape", Description: "escape", Path: "pipelines/x/pipeline.py"},
+		{Name: "symlink-escape", Description: "escape"},
 	}
 	writeManagedPipelinesManifest(t, dir, entries)
 
@@ -703,8 +664,8 @@ func TestLoadSamples_MergesManagedManifest(t *testing.T) {
 
 	managedDir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "managed-a", Description: "Managed A", Path: "managed-a.yaml"},
-		{Name: "managed-b", Description: "Managed B", Path: "managed-b.yaml"},
+		{Name: "managed-a", Description: "Managed A"},
+		{Name: "managed-b", Description: "Managed B"},
 	}
 	writeManagedPipelinesManifest(t, managedDir, entries)
 	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
@@ -743,7 +704,7 @@ func TestLoadSamples_TagsAppliedToManagedPipelines(t *testing.T) {
 
 	managedDir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "tagged-managed", Description: "Tagged", Path: "tagged-managed.yaml"},
+		{Name: "tagged-managed", Description: "Tagged"},
 	}
 	writeManagedPipelinesManifest(t, managedDir, entries)
 	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
@@ -778,8 +739,8 @@ func TestLoadSamples_ManagedDedupAgainstExplicit(t *testing.T) {
 
 	managedDir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "shared-name", Description: "managed version", Path: "shared-name.yaml"},
-		{Name: "unique-managed", Description: "only in manifest", Path: "unique-managed.yaml"},
+		{Name: "shared-name", Description: "managed version"},
+		{Name: "unique-managed", Description: "only in manifest"},
 	}
 	writeManagedPipelinesManifest(t, managedDir, entries)
 	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
@@ -804,8 +765,8 @@ func TestLoadSamples_ManagedDedupAgainstExplicit(t *testing.T) {
 func TestLoadManagedPipelinesManifest_AllDuplicates(t *testing.T) {
 	dir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "dup-a", Description: "Dup A", Path: "dup-a.yaml"},
-		{Name: "dup-b", Description: "Dup B", Path: "dup-b.yaml"},
+		{Name: "dup-a", Description: "Dup A"},
+		{Name: "dup-b", Description: "Dup B"},
 	}
 	writeManagedPipelinesManifest(t, dir, entries)
 
@@ -822,7 +783,7 @@ func TestLoadSamples_ManagedSkippedWhenLoadSamplesOnRestartFalse(t *testing.T) {
 
 	managedDir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "managed-restart", Description: "Managed", Path: "managed-restart.yaml"},
+		{Name: "managed-restart", Description: "Managed"},
 	}
 	writeManagedPipelinesManifest(t, managedDir, entries)
 	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
@@ -857,8 +818,8 @@ func TestLoadSamples_ManagedSkippedWhenLoadSamplesOnRestartFalse(t *testing.T) {
 		VersionName: "New Explicit - Ver 1",
 	})
 	newManagedEntries := []managedPipelineManifestEntry{
-		{Name: "managed-restart", Description: "Managed", Path: "managed-restart.yaml"},
-		{Name: "managed-new", Description: "New managed", Path: "managed-new.yaml"},
+		{Name: "managed-restart", Description: "Managed"},
+		{Name: "managed-new", Description: "New managed"},
 	}
 	writeManagedPipelinesManifest(t, managedDir, newManagedEntries)
 	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "managed-new.yaml"), sampleYAML, 0644))
@@ -899,9 +860,8 @@ func TestLoadSamples_EmptyManagedDir(t *testing.T) {
 }
 
 // Contract 1: The pipelines-components init container copies compiled YAMLs as
-// <name>.yaml (flat) and copies managed-pipelines.json unchanged. The manifest
-// path field is a repo-relative source location, NOT a file path in the managed
-// dir. The API server must locate files by <name>.yaml.
+// <name>.yaml (flat) and copies managed-pipelines.json unchanged.
+// The API server locates files by <name>.yaml.
 func TestLoadManagedPipelinesManifest_InitContainerContract(t *testing.T) {
 	dir := t.TempDir()
 
@@ -909,12 +869,10 @@ func TestLoadManagedPipelinesManifest_InitContainerContract(t *testing.T) {
 		{
 			Name:        "my-training-pipeline",
 			Description: "A training pipeline",
-			Path:        "pipelines/training/pipeline.py",
 		},
 		{
 			Name:        "my-evaluation-pipeline",
 			Description: "An eval pipeline",
-			Path:        "pipelines/evaluation/pipeline.py",
 		},
 	}
 	writeManagedPipelinesManifest(t, dir, entries)
@@ -949,7 +907,7 @@ func TestLoadSamples_ManifestFilename(t *testing.T) {
 
 	managedDir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "contract-pipe", Description: "d", Path: "pipelines/x/pipeline.py"},
+		{Name: "contract-pipe", Description: "d"},
 	}
 	writeManagedPipelinesManifest(t, managedDir, entries)
 	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
@@ -969,15 +927,14 @@ func TestLoadSamples_ManifestFilename(t *testing.T) {
 }
 
 // Contract 3: The manifest schema matches the Python ManagedPipelineEntry
-// dataclass: name, description, path (all lowercase). Extra fields like
-// "stability" are ignored by the Go consumer.
+// dataclass fields consumed by Go: name, description (all lowercase).
+// Extra fields like "path" and "stability" are ignored by the Go consumer.
 func TestLoadManagedPipelinesManifest_SchemaContract(t *testing.T) {
 	dir := t.TempDir()
 
 	rawJSON := `[{
 		"name": "schema-test",
-		"description": "Validates schema contract",
-		"path": "pipelines/demo/pipeline.py"
+		"description": "Validates schema contract"
 	}]`
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "managed-pipelines.json"), []byte(rawJSON), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "schema-test.yaml"), []byte("apiVersion: v2"), 0644))
@@ -1009,7 +966,7 @@ func TestLoadManagedPipelinesManifest_InvalidNamesRejected(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
 			entries := []managedPipelineManifestEntry{
-				{Name: tc.badName, Description: "bad name", Path: "p.py"},
+				{Name: tc.badName, Description: "bad name"},
 			}
 			writeManagedPipelinesManifest(t, dir, entries)
 
@@ -1041,7 +998,7 @@ func TestLoadManagedPipelinesManifest_ValidNamesAccepted(t *testing.T) {
 			require.NoError(t, os.WriteFile(filepath.Join(dir, tc.validName+".yaml"), []byte("apiVersion: v2"), 0644))
 
 			entries := []managedPipelineManifestEntry{
-				{Name: tc.validName, Description: "valid", Path: "p.py"},
+				{Name: tc.validName, Description: "valid"},
 			}
 			writeManagedPipelinesManifest(t, dir, entries)
 

--- a/backend/src/apiserver/config/config_test.go
+++ b/backend/src/apiserver/config/config_test.go
@@ -542,8 +542,8 @@ func TestLoadManagedPipelinesManifest_HappyPath(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "pipeline-b.yaml"), []byte("apiVersion: v2"), 0644))
 
 	entries := []managedPipelineManifestEntry{
-		{Name: "pipeline-a", Description: "Pipeline A", Path: "pipelines/a/pipeline.py", Stability: "stable"},
-		{Name: "pipeline-b", Description: "Pipeline B", Path: "pipelines/b/pipeline.py", Stability: "beta"},
+		{Name: "pipeline-a", Description: "Pipeline A", Path: "pipelines/a/pipeline.py"},
+		{Name: "pipeline-b", Description: "Pipeline B", Path: "pipelines/b/pipeline.py"},
 	}
 	writeManagedPipelinesManifest(t, dir, entries)
 
@@ -573,8 +573,8 @@ func TestLoadManagedPipelinesManifest_SkipDuplicates(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "new-pipeline.yaml"), []byte("apiVersion: v2"), 0644))
 
 	entries := []managedPipelineManifestEntry{
-		{Name: "existing-pipeline", Description: "Already exists", Path: "pipelines/existing/pipeline.py", Stability: "stable"},
-		{Name: "new-pipeline", Description: "New one", Path: "pipelines/new/pipeline.py", Stability: "stable"},
+		{Name: "existing-pipeline", Description: "Already exists", Path: "pipelines/existing/pipeline.py"},
+		{Name: "new-pipeline", Description: "New one", Path: "pipelines/new/pipeline.py"},
 	}
 	writeManagedPipelinesManifest(t, dir, entries)
 
@@ -597,7 +597,7 @@ func TestLoadManagedPipelinesManifest_EmptyManifest(t *testing.T) {
 func TestLoadManagedPipelinesManifest_EmptyNameRejected(t *testing.T) {
 	dir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "", Description: "No name", Path: "no-name.yaml", Stability: "stable"},
+		{Name: "", Description: "No name", Path: "no-name.yaml"},
 	}
 	writeManagedPipelinesManifest(t, dir, entries)
 
@@ -609,7 +609,7 @@ func TestLoadManagedPipelinesManifest_EmptyNameRejected(t *testing.T) {
 func TestLoadManagedPipelinesManifest_EmptyPathRejected(t *testing.T) {
 	dir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "has-name", Description: "No path", Path: "", Stability: "stable"},
+		{Name: "has-name", Description: "No path", Path: ""},
 	}
 	writeManagedPipelinesManifest(t, dir, entries)
 
@@ -641,7 +641,7 @@ func TestLoadManagedPipelinesManifest_DangerousPathFieldIgnored(t *testing.T) {
 			require.NoError(t, os.WriteFile(filepath.Join(dir, tc.entryName+".yaml"), []byte("apiVersion: v2"), 0644))
 
 			entries := []managedPipelineManifestEntry{
-				{Name: tc.entryName, Description: "Path field ignored", Path: tc.pathField, Stability: "stable"},
+				{Name: tc.entryName, Description: "Path field ignored", Path: tc.pathField},
 			}
 			writeManagedPipelinesManifest(t, dir, entries)
 
@@ -703,8 +703,8 @@ func TestLoadSamples_MergesManagedManifest(t *testing.T) {
 
 	managedDir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "managed-a", Description: "Managed A", Path: "managed-a.yaml", Stability: "stable"},
-		{Name: "managed-b", Description: "Managed B", Path: "managed-b.yaml", Stability: "stable"},
+		{Name: "managed-a", Description: "Managed A", Path: "managed-a.yaml"},
+		{Name: "managed-b", Description: "Managed B", Path: "managed-b.yaml"},
 	}
 	writeManagedPipelinesManifest(t, managedDir, entries)
 	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
@@ -743,7 +743,7 @@ func TestLoadSamples_TagsAppliedToManagedPipelines(t *testing.T) {
 
 	managedDir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "tagged-managed", Description: "Tagged", Path: "tagged-managed.yaml", Stability: "stable"},
+		{Name: "tagged-managed", Description: "Tagged", Path: "tagged-managed.yaml"},
 	}
 	writeManagedPipelinesManifest(t, managedDir, entries)
 	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
@@ -778,8 +778,8 @@ func TestLoadSamples_ManagedDedupAgainstExplicit(t *testing.T) {
 
 	managedDir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "shared-name", Description: "managed version", Path: "shared-name.yaml", Stability: "stable"},
-		{Name: "unique-managed", Description: "only in manifest", Path: "unique-managed.yaml", Stability: "stable"},
+		{Name: "shared-name", Description: "managed version", Path: "shared-name.yaml"},
+		{Name: "unique-managed", Description: "only in manifest", Path: "unique-managed.yaml"},
 	}
 	writeManagedPipelinesManifest(t, managedDir, entries)
 	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
@@ -804,8 +804,8 @@ func TestLoadSamples_ManagedDedupAgainstExplicit(t *testing.T) {
 func TestLoadManagedPipelinesManifest_AllDuplicates(t *testing.T) {
 	dir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "dup-a", Description: "Dup A", Path: "dup-a.yaml", Stability: "stable"},
-		{Name: "dup-b", Description: "Dup B", Path: "dup-b.yaml", Stability: "stable"},
+		{Name: "dup-a", Description: "Dup A", Path: "dup-a.yaml"},
+		{Name: "dup-b", Description: "Dup B", Path: "dup-b.yaml"},
 	}
 	writeManagedPipelinesManifest(t, dir, entries)
 
@@ -822,7 +822,7 @@ func TestLoadSamples_ManagedSkippedWhenLoadSamplesOnRestartFalse(t *testing.T) {
 
 	managedDir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "managed-restart", Description: "Managed", Path: "managed-restart.yaml", Stability: "stable"},
+		{Name: "managed-restart", Description: "Managed", Path: "managed-restart.yaml"},
 	}
 	writeManagedPipelinesManifest(t, managedDir, entries)
 	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
@@ -857,8 +857,8 @@ func TestLoadSamples_ManagedSkippedWhenLoadSamplesOnRestartFalse(t *testing.T) {
 		VersionName: "New Explicit - Ver 1",
 	})
 	newManagedEntries := []managedPipelineManifestEntry{
-		{Name: "managed-restart", Description: "Managed", Path: "managed-restart.yaml", Stability: "stable"},
-		{Name: "managed-new", Description: "New managed", Path: "managed-new.yaml", Stability: "stable"},
+		{Name: "managed-restart", Description: "Managed", Path: "managed-restart.yaml"},
+		{Name: "managed-new", Description: "New managed", Path: "managed-new.yaml"},
 	}
 	writeManagedPipelinesManifest(t, managedDir, newManagedEntries)
 	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "managed-new.yaml"), sampleYAML, 0644))
@@ -910,13 +910,11 @@ func TestLoadManagedPipelinesManifest_InitContainerContract(t *testing.T) {
 			Name:        "my-training-pipeline",
 			Description: "A training pipeline",
 			Path:        "pipelines/training/pipeline.py",
-			Stability:   "General Availability",
 		},
 		{
 			Name:        "my-evaluation-pipeline",
 			Description: "An eval pipeline",
 			Path:        "pipelines/evaluation/pipeline.py",
-			Stability:   "Technology Preview",
 		},
 	}
 	writeManagedPipelinesManifest(t, dir, entries)
@@ -951,7 +949,7 @@ func TestLoadSamples_ManifestFilename(t *testing.T) {
 
 	managedDir := t.TempDir()
 	entries := []managedPipelineManifestEntry{
-		{Name: "contract-pipe", Description: "d", Path: "pipelines/x/pipeline.py", Stability: "stable"},
+		{Name: "contract-pipe", Description: "d", Path: "pipelines/x/pipeline.py"},
 	}
 	writeManagedPipelinesManifest(t, managedDir, entries)
 	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
@@ -971,15 +969,15 @@ func TestLoadSamples_ManifestFilename(t *testing.T) {
 }
 
 // Contract 3: The manifest schema matches the Python ManagedPipelineEntry
-// dataclass: name, description, path, stability (all lowercase).
+// dataclass: name, description, path (all lowercase). Extra fields like
+// "stability" are ignored by the Go consumer.
 func TestLoadManagedPipelinesManifest_SchemaContract(t *testing.T) {
 	dir := t.TempDir()
 
 	rawJSON := `[{
 		"name": "schema-test",
 		"description": "Validates schema contract",
-		"path": "pipelines/demo/pipeline.py",
-		"stability": "General Availability"
+		"path": "pipelines/demo/pipeline.py"
 	}]`
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "managed-pipelines.json"), []byte(rawJSON), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "schema-test.yaml"), []byte("apiVersion: v2"), 0644))
@@ -1005,7 +1003,7 @@ func TestLoadManagedPipelinesManifest_InvalidNamesRejected(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
 			entries := []managedPipelineManifestEntry{
-				{Name: tc.badName, Description: "bad name", Path: "p.py", Stability: "s"},
+				{Name: tc.badName, Description: "bad name", Path: "p.py"},
 			}
 			writeManagedPipelinesManifest(t, dir, entries)
 

--- a/backend/src/apiserver/config/config_test.go
+++ b/backend/src/apiserver/config/config_test.go
@@ -54,7 +54,7 @@ func TestLoadSamplesConfigBackwardsCompatibility(t *testing.T) {
 
 	path, err := writeSampleConfigDeprecated(t, pc, "sample.json")
 	require.NoError(t, err)
-	err = LoadSamples(rm, path)
+	err = LoadSamples(rm, path, "")
 	require.NoError(t, err)
 
 	_, err = rm.GetPipelineByNameAndNamespace(pc[0].Name, "")
@@ -73,7 +73,7 @@ func TestLoadSamplesConfigBackwardsCompatibility(t *testing.T) {
 	require.NoError(t, err)
 
 	// Loading samples should result in no pipeline uploaded
-	err = LoadSamples(rm, path)
+	err = LoadSamples(rm, path, "")
 	require.NoError(t, err)
 	_, err = rm.GetPipelineByNameAndNamespace(pc[0].Name, "")
 	var userErr *util.UserError
@@ -142,7 +142,7 @@ func TestLoadSamples(t *testing.T) {
 
 	path, err := writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	err = LoadSamples(rm, path)
+	err = LoadSamples(rm, path, "")
 	require.NoError(t, err)
 
 	var pipeline1 *model.Pipeline
@@ -201,7 +201,7 @@ func TestLoadSamples(t *testing.T) {
 	pc.Pipelines[0].VersionName = "Pipeline 1 - Ver 2"
 	path, err = writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	err = LoadSamples(rm, path)
+	err = LoadSamples(rm, path, "")
 	require.NoError(t, err)
 
 	// Expect another Pipeline version added for Pipeline 1
@@ -215,7 +215,7 @@ func TestLoadSamples(t *testing.T) {
 	pc.Pipelines[1].VersionName = "Pipeline 2 - Ver 2"
 	path, err = writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	err = LoadSamples(rm, path)
+	err = LoadSamples(rm, path, "")
 	require.NoError(t, err)
 
 	// Expect another Pipeline version added for Pipeline 2
@@ -238,7 +238,7 @@ func TestLoadSamples(t *testing.T) {
 	pc.Pipelines[1].VersionName = "Pipeline 2 - Ver 3"
 	path, err = writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	err = LoadSamples(rm, path)
+	err = LoadSamples(rm, path, "")
 	require.NoError(t, err)
 
 	// Expect no change
@@ -271,7 +271,7 @@ func TestLoadSamplesMultiplePipelineVersionsInConfig(t *testing.T) {
 
 	path, err := writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	err = LoadSamples(rm, path)
+	err = LoadSamples(rm, path, "")
 	require.NoError(t, err)
 
 	// Expect both versions to be added
@@ -379,7 +379,7 @@ func TestLoadSamples_TagsApplied(t *testing.T) {
 
 	path, err := writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 
 	pipeline, err := rm.GetPipelineByNameAndNamespace("Tagged Pipeline", "")
 	require.NoError(t, err)
@@ -409,7 +409,7 @@ func TestLoadSamples_NoTagsWhenEnvUnset(t *testing.T) {
 
 	path, err := writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 
 	pipeline, err := rm.GetPipelineByNameAndNamespace("Untagged Pipeline", "")
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestLoadSamples_MalformedTagsReturnsError(t *testing.T) {
 
 	path, err := writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	err = LoadSamples(rm, path)
+	err = LoadSamples(rm, path, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "badentry")
 }
@@ -464,14 +464,14 @@ func TestLoadSamples_MalformedTagsIgnoredWhenLoadingSkipped(t *testing.T) {
 	t.Setenv(managedPipelinesUploadTagsEnv, "")
 	path, err := writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 
 	// Second load: samples already loaded + LoadSamplesOnRestart=false → skip.
 	// A malformed env var must NOT cause an error because loading is skipped.
 	t.Setenv(managedPipelinesUploadTagsEnv, "badentry")
 	path, err = writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 }
 
 func TestLoadSamples_ExistingPipelineNotRetagged(t *testing.T) {
@@ -493,14 +493,14 @@ func TestLoadSamples_ExistingPipelineNotRetagged(t *testing.T) {
 	}
 	path, err := writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 
 	// Second load: add a new version with tags enabled
 	t.Setenv(managedPipelinesUploadTagsEnv, "managed=true")
 	pc.Pipelines[0].VersionName = "Existing Pipeline - Ver 2"
 	path, err = writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 
 	// Existing pipeline should NOT have been re-tagged
 	pipeline, err := rm.GetPipelineByNameAndNamespace("Existing Pipeline", "")
@@ -527,4 +527,491 @@ func writeContents(t *testing.T, content interface{}, path string) (string, erro
 		t.Fatalf("Failed to create %v file: %v", path, err)
 	}
 	return sampleFilePath, nil
+}
+
+func writeManagedPipelinesManifest(t *testing.T, dir string, entries []managedPipelineManifestEntry) {
+	t.Helper()
+	data, err := json.Marshal(entries)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "managed-pipelines.json"), data, 0644))
+}
+
+func TestLoadManagedPipelinesManifest_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "pipeline-a.yaml"), []byte("apiVersion: v2"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "pipeline-b.yaml"), []byte("apiVersion: v2"), 0644))
+
+	entries := []managedPipelineManifestEntry{
+		{Name: "pipeline-a", Description: "Pipeline A", Path: "pipelines/a/pipeline.py", Stability: "stable"},
+		{Name: "pipeline-b", Description: "Pipeline B", Path: "pipelines/b/pipeline.py", Stability: "beta"},
+	}
+	writeManagedPipelinesManifest(t, dir, entries)
+
+	got, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, "pipeline-a", got[0].Name)
+	assert.Equal(t, "Pipeline A", got[0].Description)
+	assert.Equal(t, filepath.Join(resolvedDir, "pipeline-a.yaml"), got[0].File)
+	assert.Equal(t, "pipeline-b", got[1].Name)
+	assert.Equal(t, "Pipeline B", got[1].Description)
+	assert.Equal(t, filepath.Join(resolvedDir, "pipeline-b.yaml"), got[1].File)
+}
+
+func TestLoadManagedPipelinesManifest_DirNotExist(t *testing.T) {
+	got, err := loadManagedPipelinesManifest("/nonexistent/managed-pipelines.json", nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestLoadManagedPipelinesManifest_SkipDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "new-pipeline.yaml"), []byte("apiVersion: v2"), 0644))
+
+	entries := []managedPipelineManifestEntry{
+		{Name: "existing-pipeline", Description: "Already exists", Path: "pipelines/existing/pipeline.py", Stability: "stable"},
+		{Name: "new-pipeline", Description: "New one", Path: "pipelines/new/pipeline.py", Stability: "stable"},
+	}
+	writeManagedPipelinesManifest(t, dir, entries)
+
+	existing := map[string]bool{"existing-pipeline": true}
+	got, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), existing)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "new-pipeline", got[0].Name)
+}
+
+func TestLoadManagedPipelinesManifest_EmptyManifest(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "managed-pipelines.json"), []byte("[]"), 0644))
+
+	got, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestLoadManagedPipelinesManifest_EmptyNameRejected(t *testing.T) {
+	dir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "", Description: "No name", Path: "no-name.yaml", Stability: "stable"},
+	}
+	writeManagedPipelinesManifest(t, dir, entries)
+
+	_, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty name")
+}
+
+func TestLoadManagedPipelinesManifest_EmptyPathRejected(t *testing.T) {
+	dir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "has-name", Description: "No path", Path: "", Stability: "stable"},
+	}
+	writeManagedPipelinesManifest(t, dir, entries)
+
+	_, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty path")
+}
+
+func TestLoadManagedPipelinesManifest_MalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "managed-pipelines.json"), []byte("{bad json"), 0644))
+
+	_, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
+	require.Error(t, err)
+}
+
+func TestLoadManagedPipelinesManifest_DangerousPathFieldIgnored(t *testing.T) {
+	cases := []struct {
+		name      string
+		entryName string
+		pathField string
+	}{
+		{"traversal path", "safe-name", "../escape.yaml"},
+		{"absolute path", "absolute", "/etc/passwd"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, tc.entryName+".yaml"), []byte("apiVersion: v2"), 0644))
+
+			entries := []managedPipelineManifestEntry{
+				{Name: tc.entryName, Description: "Path field ignored", Path: tc.pathField, Stability: "stable"},
+			}
+			writeManagedPipelinesManifest(t, dir, entries)
+
+			got, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
+			require.NoError(t, err, "Path field is metadata-only; dangerous values do not affect file resolution")
+			require.Len(t, got, 1)
+			assert.Equal(t, tc.entryName+".yaml", filepath.Base(got[0].File))
+		})
+	}
+}
+
+func TestLoadManagedPipelinesManifest_DuplicateNamesRejected(t *testing.T) {
+	dir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "dup", Description: "first", Path: "a.yaml"},
+		{Name: "dup", Description: "second", Path: "b.yaml"},
+	}
+	writeManagedPipelinesManifest(t, dir, entries)
+
+	_, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate name")
+}
+
+func TestLoadManagedPipelinesManifest_SymlinkEscapeRejected(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "escape.yaml")
+	require.NoError(t, os.WriteFile(outside, []byte("apiVersion: v2"), 0644))
+	require.NoError(t, os.Symlink(outside, filepath.Join(dir, "symlink-escape.yaml")))
+
+	entries := []managedPipelineManifestEntry{
+		{Name: "symlink-escape", Description: "escape", Path: "pipelines/x/pipeline.py"},
+	}
+	writeManagedPipelinesManifest(t, dir, entries)
+
+	_, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes directory")
+}
+
+func TestLoadSamples_MergesManagedManifest(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	t.Setenv(managedPipelinesUploadTagsEnv, "")
+	rm := fakeResourceManager()
+
+	pc := config{
+		LoadSamplesOnRestart: true,
+		Pipelines: []configPipelines{
+			{
+				Name:        "Explicit Pipeline",
+				Description: "from sample_config.json",
+				File:        "testdata/sample_pipeline.yaml",
+				VersionName: "Explicit Pipeline - Ver 1",
+			},
+		},
+	}
+	samplePath, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+
+	managedDir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "managed-a", Description: "Managed A", Path: "managed-a.yaml", Stability: "stable"},
+		{Name: "managed-b", Description: "Managed B", Path: "managed-b.yaml", Stability: "stable"},
+	}
+	writeManagedPipelinesManifest(t, managedDir, entries)
+	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "managed-a.yaml"), sampleYAML, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "managed-b.yaml"), sampleYAML, 0644))
+
+	require.NoError(t, LoadSamples(rm, samplePath, managedDir))
+
+	_, err = rm.GetPipelineByNameAndNamespace("Explicit Pipeline", "")
+	require.NoError(t, err)
+	_, err = rm.GetPipelineByNameAndNamespace("managed-a", "")
+	require.NoError(t, err)
+	_, err = rm.GetPipelineByNameAndNamespace("managed-b", "")
+	require.NoError(t, err)
+
+	_, err = rm.GetPipelineVersionByName("Explicit Pipeline - Ver 1")
+	require.NoError(t, err)
+	_, err = rm.GetPipelineVersionByName("managed-a")
+	require.NoError(t, err)
+	_, err = rm.GetPipelineVersionByName("managed-b")
+	require.NoError(t, err)
+}
+
+func TestLoadSamples_TagsAppliedToManagedPipelines(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	t.Setenv(managedPipelinesUploadTagsEnv, "managed=true")
+	rm := fakeResourceManager()
+
+	pc := config{
+		LoadSamplesOnRestart: true,
+		Pipelines:            []configPipelines{},
+	}
+	samplePath, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+
+	managedDir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "tagged-managed", Description: "Tagged", Path: "tagged-managed.yaml", Stability: "stable"},
+	}
+	writeManagedPipelinesManifest(t, managedDir, entries)
+	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "tagged-managed.yaml"), sampleYAML, 0644))
+
+	require.NoError(t, LoadSamples(rm, samplePath, managedDir))
+
+	pipeline, err := rm.GetPipelineByNameAndNamespace("tagged-managed", "")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"managed": "true"}, pipeline.Tags)
+}
+
+func TestLoadSamples_ManagedDedupAgainstExplicit(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	t.Setenv(managedPipelinesUploadTagsEnv, "")
+	rm := fakeResourceManager()
+
+	pc := config{
+		LoadSamplesOnRestart: true,
+		Pipelines: []configPipelines{
+			{
+				Name:        "shared-name",
+				Description: "explicit version",
+				File:        "testdata/sample_pipeline.yaml",
+				VersionName: "shared-name - Ver 1",
+			},
+		},
+	}
+	samplePath, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+
+	managedDir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "shared-name", Description: "managed version", Path: "shared-name.yaml", Stability: "stable"},
+		{Name: "unique-managed", Description: "only in manifest", Path: "unique-managed.yaml", Stability: "stable"},
+	}
+	writeManagedPipelinesManifest(t, managedDir, entries)
+	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "shared-name.yaml"), sampleYAML, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "unique-managed.yaml"), sampleYAML, 0644))
+
+	require.NoError(t, LoadSamples(rm, samplePath, managedDir))
+
+	pipeline, err := rm.GetPipelineByNameAndNamespace("shared-name", "")
+	require.NoError(t, err)
+	opts, err := list.NewOptions(&model.PipelineVersion{}, 10, "id", nil)
+	require.NoError(t, err)
+	_, totalSize, _, err := rm.ListPipelineVersions(pipeline.UUID, opts, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, totalSize)
+
+	_, err = rm.GetPipelineByNameAndNamespace("unique-managed", "")
+	require.NoError(t, err)
+}
+
+func TestLoadManagedPipelinesManifest_AllDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "dup-a", Description: "Dup A", Path: "dup-a.yaml", Stability: "stable"},
+		{Name: "dup-b", Description: "Dup B", Path: "dup-b.yaml", Stability: "stable"},
+	}
+	writeManagedPipelinesManifest(t, dir, entries)
+
+	existing := map[string]bool{"dup-a": true, "dup-b": true}
+	got, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), existing)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestLoadSamples_ManagedSkippedWhenLoadSamplesOnRestartFalse(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	t.Setenv(managedPipelinesUploadTagsEnv, "")
+	rm := fakeResourceManager()
+
+	managedDir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "managed-restart", Description: "Managed", Path: "managed-restart.yaml", Stability: "stable"},
+	}
+	writeManagedPipelinesManifest(t, managedDir, entries)
+	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "managed-restart.yaml"), sampleYAML, 0644))
+
+	pc := config{
+		LoadSamplesOnRestart: false,
+		Pipelines: []configPipelines{
+			{
+				Name:        "Initial Pipeline",
+				Description: "test",
+				File:        "testdata/sample_pipeline.yaml",
+				VersionName: "Initial Pipeline - Ver 1",
+			},
+		},
+	}
+
+	path, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, path, managedDir))
+
+	_, err = rm.GetPipelineByNameAndNamespace("Initial Pipeline", "")
+	require.NoError(t, err)
+	_, err = rm.GetPipelineByNameAndNamespace("managed-restart", "")
+	require.NoError(t, err)
+
+	pc.Pipelines = append(pc.Pipelines, configPipelines{
+		Name:        "New Explicit",
+		Description: "added after first load",
+		File:        "testdata/sample_pipeline.yaml",
+		VersionName: "New Explicit - Ver 1",
+	})
+	newManagedEntries := []managedPipelineManifestEntry{
+		{Name: "managed-restart", Description: "Managed", Path: "managed-restart.yaml", Stability: "stable"},
+		{Name: "managed-new", Description: "New managed", Path: "managed-new.yaml", Stability: "stable"},
+	}
+	writeManagedPipelinesManifest(t, managedDir, newManagedEntries)
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "managed-new.yaml"), sampleYAML, 0644))
+
+	path, err = writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, path, managedDir))
+
+	_, err = rm.GetPipelineByNameAndNamespace("New Explicit", "")
+	require.Error(t, err, "new explicit pipeline should not be loaded on restart with LoadSamplesOnRestart=false")
+	_, err = rm.GetPipelineByNameAndNamespace("managed-new", "")
+	require.Error(t, err, "new managed pipeline should not be loaded on restart with LoadSamplesOnRestart=false")
+}
+
+func TestLoadSamples_EmptyManagedDir(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	t.Setenv(managedPipelinesUploadTagsEnv, "")
+	rm := fakeResourceManager()
+
+	pc := config{
+		LoadSamplesOnRestart: true,
+		Pipelines: []configPipelines{
+			{
+				Name:        "Solo Pipeline",
+				Description: "test",
+				File:        "testdata/sample_pipeline.yaml",
+				VersionName: "Solo Pipeline - Ver 1",
+			},
+		},
+	}
+	path, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+
+	require.NoError(t, LoadSamples(rm, path, ""))
+
+	_, err = rm.GetPipelineByNameAndNamespace("Solo Pipeline", "")
+	require.NoError(t, err)
+}
+
+// Contract 1: The pipelines-components init container copies compiled YAMLs as
+// <name>.yaml (flat) and copies managed-pipelines.json unchanged. The manifest
+// path field is a repo-relative source location, NOT a file path in the managed
+// dir. The API server must locate files by <name>.yaml.
+func TestLoadManagedPipelinesManifest_InitContainerContract(t *testing.T) {
+	dir := t.TempDir()
+
+	entries := []managedPipelineManifestEntry{
+		{
+			Name:        "my-training-pipeline",
+			Description: "A training pipeline",
+			Path:        "pipelines/training/pipeline.py",
+			Stability:   "General Availability",
+		},
+		{
+			Name:        "my-evaluation-pipeline",
+			Description: "An eval pipeline",
+			Path:        "pipelines/evaluation/pipeline.py",
+			Stability:   "Technology Preview",
+		},
+	}
+	writeManagedPipelinesManifest(t, dir, entries)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "my-training-pipeline.yaml"), []byte("apiVersion: v2"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "my-evaluation-pipeline.yaml"), []byte("apiVersion: v2"), 0644))
+
+	got, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	assert.Equal(t, "my-training-pipeline", got[0].Name)
+	assert.Equal(t, "A training pipeline", got[0].Description)
+	assert.True(t, filepath.IsAbs(got[0].File), "File should be absolute")
+	assert.Equal(t, "my-training-pipeline.yaml", filepath.Base(got[0].File))
+
+	assert.Equal(t, "my-evaluation-pipeline", got[1].Name)
+	assert.Equal(t, "An eval pipeline", got[1].Description)
+	assert.True(t, filepath.IsAbs(got[1].File), "File should be absolute")
+	assert.Equal(t, "my-evaluation-pipeline.yaml", filepath.Base(got[1].File))
+}
+
+// Contract 2: LoadSamples expects the manifest at <dir>/managed-pipelines.json.
+func TestLoadSamples_ManifestFilename(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	t.Setenv(managedPipelinesUploadTagsEnv, "")
+	rm := fakeResourceManager()
+
+	pc := config{LoadSamplesOnRestart: true, Pipelines: []configPipelines{}}
+	samplePath, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+
+	managedDir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "contract-pipe", Description: "d", Path: "pipelines/x/pipeline.py", Stability: "stable"},
+	}
+	writeManagedPipelinesManifest(t, managedDir, entries)
+	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "contract-pipe.yaml"), sampleYAML, 0644))
+
+	require.NoError(t, LoadSamples(rm, samplePath, managedDir))
+
+	_, err = rm.GetPipelineByNameAndNamespace("contract-pipe", "")
+	require.NoError(t, err)
+
+	wrongDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(wrongDir, "pipelines.json"), []byte("[]"), 0644))
+
+	require.NoError(t, LoadSamples(rm, samplePath, wrongDir),
+		"missing managed-pipelines.json is silently ignored (volume not mounted)")
+}
+
+// Contract 3: The manifest schema matches the Python ManagedPipelineEntry
+// dataclass: name, description, path, stability (all lowercase).
+func TestLoadManagedPipelinesManifest_SchemaContract(t *testing.T) {
+	dir := t.TempDir()
+
+	rawJSON := `[{
+		"name": "schema-test",
+		"description": "Validates schema contract",
+		"path": "pipelines/demo/pipeline.py",
+		"stability": "General Availability"
+	}]`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "managed-pipelines.json"), []byte(rawJSON), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "schema-test.yaml"), []byte("apiVersion: v2"), 0644))
+
+	got, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "schema-test", got[0].Name)
+	assert.Equal(t, "Validates schema contract", got[0].Description)
+}
+
+func TestLoadManagedPipelinesManifest_InvalidNamesRejected(t *testing.T) {
+	cases := []struct {
+		name    string
+		badName string
+	}{
+		{"traversal with slashes", "../../etc/passwd"},
+		{"forward slash", "sub/dir"},
+		{"backslash", "pipe\\line"},
+		{"dot-dot without separator", "pipe..line"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			entries := []managedPipelineManifestEntry{
+				{Name: tc.badName, Description: "bad name", Path: "p.py", Stability: "s"},
+			}
+			writeManagedPipelinesManifest(t, dir, entries)
+
+			_, err := loadManagedPipelinesManifest(filepath.Join(dir, "managed-pipelines.json"), nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid character")
+		})
+	}
 }

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -77,6 +77,7 @@ var (
 	webhookTLSKeyPath             = flag.String("webhookTLSKeyPath", "", "Path to the webhook TLS private key. Defaults to tlsCertKeyPath value")
 	configPath                    = flag.String("config", "", "Path to JSON file containing config")
 	sampleConfigPath              = flag.String("sampleconfig", "", "Path to samples")
+	managedPipelinesDir           = flag.String("managedPipelinesDir", "", "Directory containing managed-pipelines.json manifest")
 	tlsCertPath                   = flag.String("tlsCertPath", "", "Path to the public TLS cert.")
 	tlsCertKeyPath                = flag.String("tlsCertKeyPath", "", "Path to the private TLS key cert.")
 	collectMetricsFlag            = flag.Bool("collectMetricsFlag", true, "Whether to collect Prometheus metrics in API server.")
@@ -231,7 +232,7 @@ func main() {
 			DefaultRunAsNonRoot:  parseOptionalBool(common.GetDefaultSecurityContextRunAsNonRoot()),
 		},
 	)
-	err = config.LoadSamples(resourceManager, *sampleConfigPath)
+	err = config.LoadSamples(resourceManager, *sampleConfigPath, *managedPipelinesDir)
 	if err != nil {
 		glog.Fatalf("Failed to load samples. Err: %v", err)
 	}


### PR DESCRIPTION
**Description of your changes:**

- Introduced `managedPipelinesDir` flag to specify a directory containing managed-pipelines.json manifests.
- Enhanced `LoadSamples` to process managed pipelines manifest, merge entries, ensure unique pipeline names, and validate paths.
- Added extensive unit tests for manifest parsing, path validation, and integration with existing logic.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [x] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option to load an additional managed-pipelines manifest; entries from that manifest are merged into sample pipelines.
  * Manifest entries are validated; duplicates by name are skipped, invalid entries are rejected, and pipeline file paths are resolved with directory/symlink safety checks. Missing manifest is treated as no-op.

* **Tests**
  * Added extensive tests for manifest parsing, validation, deduplication, path-safety, and integration with sample loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->