### PR TITLE
fix(ci): Update kube-rbac-proxy image registry in deploy script

### DIFF
--- a/.github/actions/deploy/operator_deployer.py
+++ b/.github/actions/deploy/operator_deployer.py
@@ -113,7 +113,7 @@ class OperatorDeployer:
 
         replacements = {
             'registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:latest':
-                'gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0',
+                'registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0',
             'registry.redhat.io/rhel9/mariadb-105:latest':
                 'quay.io/sclorg/mariadb-105-c9s:latest',
             'registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6':

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -111,6 +111,7 @@ jobs:
           image_registry: ${{ needs.build.outputs.IMAGE_REGISTRY }}
           forward_port: 'false'
           skip_operator_deployment: 'false'
+          pod_to_pod_tls_enabled: ${{ matrix.tls_enabled }}
 
       - name: Verify Upgrade
         uses: ./.github/actions/test-and-report


### PR DESCRIPTION
**Description of your changes:**

Cherry-pick of #320 to `stable`.                                                                                                                                                                                                         

Switches the `kube-rbac-proxy` image from the deprecated `gcr.io/kubebuilder/kube-rbac-proxy` registry to `registry.k8s.io/kubebuilder/kube-rbac-proxy`, the official Kubernetes community registry.

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [ ] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
