### PR TITLE
UPSTREAM<carry>: fix(ci): Enable pod-to-pod TLS configuration in upgrade test workflow

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -111,6 +111,7 @@ jobs:
           image_registry: ${{ needs.build.outputs.IMAGE_REGISTRY }}
           forward_port: 'false'
           skip_operator_deployment: 'false'
+          pod_to_pod_tls_enabled: ${{ matrix.tls_enabled }}
 
       - name: Verify Upgrade
         uses: ./.github/actions/test-and-report


### PR DESCRIPTION
**Description of your changes:**

The "Deploy from Branch" step in the upgrade test was missing the pod_to_pod_tls_enabled parameter, defaulting to false while "Deploy Last Release" sets it to true. When both steps use the same operator image (e.g. on the stable branch), the operator deployment is unchanged and the old API server pod keeps running with TLS-enabled config against a reconfigured non-TLS database, causing all verification tests to fail with "TLS requested but server does not support TLS".


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [x] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to ensure consistent transport security (TLS) configuration is properly applied across all deployment and upgrade operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->