### PR TITLE
UPSTREAM<carry>: fix(ci): Conditionalize operator deployment in workflows

### DIFF
--- a/.github/workflows/api-server-tests.yml
+++ b/.github/workflows/api-server-tests.yml
@@ -111,7 +111,7 @@ jobs:
           image_path: ${{ needs.build.outputs.IMAGE_PATH }}
           image_tag: ${{ needs.build.outputs.IMAGE_TAG }}
           image_registry: ${{ needs.build.outputs.IMAGE_REGISTRY }}
-          skip_operator_deployment: 'false'
+          skip_operator_deployment: ${{ github.repository_owner != 'opendatahub-io' }}
 
       - name: Configure Cluster CA Cert for TLS-Enabled Tests
         shell: bash
@@ -208,7 +208,7 @@ jobs:
           image_tag: ${{ needs.build.outputs.IMAGE_TAG }}
           image_registry: ${{ needs.build.outputs.IMAGE_REGISTRY }}
           pod_to_pod_tls_enabled: ${{ matrix.pod_to_pod_tls_enabled }}
-          skip_operator_deployment: 'false'
+          skip_operator_deployment: ${{ github.repository_owner != 'opendatahub-io' }}
 
       - name: Run Tests
         uses: ./.github/actions/test-and-report

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -141,7 +141,7 @@ jobs:
           image_path: ${{ needs.build.outputs.IMAGE_PATH }}
           image_tag: ${{ needs.build.outputs.IMAGE_TAG }}
           image_registry: ${{ needs.build.outputs.IMAGE_REGISTRY }}
-          skip_operator_deployment: 'false'
+          skip_operator_deployment: ${{ github.repository_owner != 'opendatahub-io' }}
 
       - name: Configure Cluster CA Cert for TLS-Enabled Tests
         shell: bash

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -74,7 +74,7 @@ jobs:
           pod_to_pod_tls_enabled: ${{ matrix.tls_enabled }}
           operator_image_tag: "odh-stable"
           skip_load_docker_images: 'true'
-          skip_operator_deployment: 'false'
+          skip_operator_deployment: ${{ github.repository_owner != 'opendatahub-io' }}
           operator_branch: 'stable'
 
       - name: Configure Cluster CA e2e for TLS-Enabled Tests
@@ -110,7 +110,7 @@ jobs:
           image_tag: ${{ needs.build.outputs.IMAGE_TAG }}
           image_registry: ${{ needs.build.outputs.IMAGE_REGISTRY }}
           forward_port: 'false'
-          skip_operator_deployment: 'false'
+          skip_operator_deployment: ${{ github.repository_owner != 'opendatahub-io' }}
           pod_to_pod_tls_enabled: ${{ matrix.tls_enabled }}
 
       - name: Verify Upgrade


### PR DESCRIPTION
**Description of your changes:**
Make skip_operator_deployment conditional on github.repository_owner so downstream forks that lack access to the operator image fall back to direct manifest deployment automatically.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [x] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to conditionally manage operator deployment based on repository ownership, affecting test execution behavior in forked and non-official repository environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->