### PR TITLE
UPSTREAM<carry>: fix(ci): Update service account name to 'pipeline-runner' in deployment script

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -109,6 +109,9 @@ outputs:
   service_account_name:
     description: "Name of the KFP API server service account"
     value: ${{ steps.deploy-kfp.outputs.SERVICE_ACCOUNT_NAME }}
+  pipeline_runner_service_account:
+    description: "Service account for pipeline execution (may differ from API server SA)"
+    value: ${{ steps.deploy-kfp.outputs.PIPELINE_RUNNER_SERVICE_ACCOUNT }}
   deployment_mode:
     description: "Deployment mode used (operator or direct)"
     value: ${{ steps.deploy-kfp.outputs.DEPLOYMENT_MODE }}

--- a/.github/actions/deploy/dspa_deployer.py
+++ b/.github/actions/deploy/dspa_deployer.py
@@ -246,7 +246,7 @@ class DSPADeployer:
             frontend_service_name = f'ds-pipeline-ui-{self.dspa_name}'
         else:
             deployment_name = 'ml-pipeline'
-            service_account_name = 'ml-pipeline'
+            service_account_name = 'pipeline-runner'
             database_name = 'mysql'
             mlmd_service_name = 'metadata-grpc-service'
             frontend_service_name = 'ml-pipeline-ui'

--- a/.github/actions/deploy/dspa_deployer.py
+++ b/.github/actions/deploy/dspa_deployer.py
@@ -241,12 +241,14 @@ class DSPADeployer:
         if is_operator:
             deployment_name = f'ds-pipeline-{self.dspa_name}'
             service_account_name = f'ds-pipeline-{self.dspa_name}'
+            pipeline_runner_service_account = f'pipeline-runner-{self.dspa_name}'
             database_name = f'ds-pipeline-db-{self.dspa_name}'
             mlmd_service_name = f'ds-pipeline-metadata-grpc-{self.dspa_name}'
             frontend_service_name = f'ds-pipeline-ui-{self.dspa_name}'
         else:
             deployment_name = 'ml-pipeline'
-            service_account_name = 'pipeline-runner'
+            service_account_name = 'ml-pipeline'
+            pipeline_runner_service_account = 'pipeline-runner'
             database_name = 'mysql'
             mlmd_service_name = 'metadata-grpc-service'
             frontend_service_name = 'ml-pipeline-ui'
@@ -255,6 +257,7 @@ class DSPADeployer:
         print(f'   DEPLOYMENT_MODE={deployment_mode}')
         print(f'   DEPLOYMENT_NAME={deployment_name}')
         print(f'   SERVICE_ACCOUNT_NAME={service_account_name}')
+        print(f'   PIPELINE_RUNNER_SERVICE_ACCOUNT={pipeline_runner_service_account}')
         print(f'   DATABASE_NAME={database_name}')
         print(f'   MLMD_SERVICE_NAME={mlmd_service_name}')
         print(f'   FRONTEND_SERVICE_NAME={frontend_service_name}')
@@ -263,6 +266,7 @@ class DSPADeployer:
             'DEPLOYMENT_MODE': deployment_mode,
             'DEPLOYMENT_NAME': deployment_name,
             'SERVICE_ACCOUNT_NAME': service_account_name,
+            'PIPELINE_RUNNER_SERVICE_ACCOUNT': pipeline_runner_service_account,
             'DATABASE_NAME': database_name,
             'MLMD_SERVICE_NAME': mlmd_service_name,
             'FRONTEND_SERVICE_NAME': frontend_service_name,

--- a/.github/actions/deploy/test_dspa_deployer.py
+++ b/.github/actions/deploy/test_dspa_deployer.py
@@ -1,0 +1,122 @@
+"""Tests for DSPADeployer.output_deployment_metadata()."""
+
+import unittest
+from unittest.mock import MagicMock
+
+from dspa_deployer import DSPADeployer
+
+
+def _make_deployer(dspa_name: str = 'test-dspa') -> DSPADeployer:
+    """Create a DSPADeployer with stubbed-out dependencies."""
+    args = MagicMock()
+    deployment_manager = MagicMock()
+    return DSPADeployer(
+        args=args,
+        deployment_manager=deployment_manager,
+        deployment_namespace='test-ns',
+        dspa_name=dspa_name,
+        external_db_namespace='ext-db-ns',
+        operator_namespace='opendatahub',
+        temp_dir='/tmp/test',
+    )
+
+
+class TestOutputDeploymentMetadataDirect(unittest.TestCase):
+    """Direct (non-operator) mode metadata."""
+
+    def setUp(self):
+        self.metadata = _make_deployer().output_deployment_metadata(
+            is_operator=False)
+
+    def test_deployment_mode(self):
+        self.assertEqual(self.metadata['DEPLOYMENT_MODE'], 'direct')
+
+    def test_deployment_name(self):
+        self.assertEqual(self.metadata['DEPLOYMENT_NAME'], 'ml-pipeline')
+
+    def test_service_account_is_api_server_sa(self):
+        self.assertEqual(self.metadata['SERVICE_ACCOUNT_NAME'], 'ml-pipeline')
+
+    def test_pipeline_runner_service_account(self):
+        self.assertEqual(
+            self.metadata['PIPELINE_RUNNER_SERVICE_ACCOUNT'],
+            'pipeline-runner',
+        )
+
+    def test_database_name(self):
+        self.assertEqual(self.metadata['DATABASE_NAME'], 'mysql')
+
+    def test_mlmd_service_name(self):
+        self.assertEqual(self.metadata['MLMD_SERVICE_NAME'],
+                         'metadata-grpc-service')
+
+    def test_frontend_service_name(self):
+        self.assertEqual(self.metadata['FRONTEND_SERVICE_NAME'],
+                         'ml-pipeline-ui')
+
+
+class TestOutputDeploymentMetadataOperator(unittest.TestCase):
+    """Operator mode metadata."""
+
+    def setUp(self):
+        self.dspa_name = 'my-dspa'
+        self.metadata = _make_deployer(
+            dspa_name=self.dspa_name).output_deployment_metadata(
+                is_operator=True)
+
+    def test_deployment_mode(self):
+        self.assertEqual(self.metadata['DEPLOYMENT_MODE'], 'operator')
+
+    def test_deployment_name(self):
+        self.assertEqual(self.metadata['DEPLOYMENT_NAME'],
+                         f'ds-pipeline-{self.dspa_name}')
+
+    def test_service_account_is_api_server_sa(self):
+        self.assertEqual(self.metadata['SERVICE_ACCOUNT_NAME'],
+                         f'ds-pipeline-{self.dspa_name}')
+
+    def test_pipeline_runner_service_account(self):
+        self.assertEqual(
+            self.metadata['PIPELINE_RUNNER_SERVICE_ACCOUNT'],
+            f'pipeline-runner-{self.dspa_name}',
+        )
+
+    def test_database_name(self):
+        self.assertEqual(self.metadata['DATABASE_NAME'],
+                         f'ds-pipeline-db-{self.dspa_name}')
+
+    def test_mlmd_service_name(self):
+        self.assertEqual(self.metadata['MLMD_SERVICE_NAME'],
+                         f'ds-pipeline-metadata-grpc-{self.dspa_name}')
+
+    def test_frontend_service_name(self):
+        self.assertEqual(self.metadata['FRONTEND_SERVICE_NAME'],
+                         f'ds-pipeline-ui-{self.dspa_name}')
+
+
+class TestOutputDeploymentMetadataKeys(unittest.TestCase):
+    """Both modes must return exactly the expected set of keys."""
+
+    EXPECTED_KEYS = {
+        'DEPLOYMENT_MODE',
+        'DEPLOYMENT_NAME',
+        'SERVICE_ACCOUNT_NAME',
+        'PIPELINE_RUNNER_SERVICE_ACCOUNT',
+        'DATABASE_NAME',
+        'MLMD_SERVICE_NAME',
+        'FRONTEND_SERVICE_NAME',
+    }
+
+    def test_direct_mode_keys(self):
+        metadata = _make_deployer().output_deployment_metadata(
+            is_operator=False)
+        self.assertEqual(set(metadata.keys()), self.EXPECTED_KEYS)
+
+    def test_operator_mode_keys(self):
+        metadata = _make_deployer().output_deployment_metadata(
+            is_operator=True)
+        self.assertEqual(set(metadata.keys()), self.EXPECTED_KEYS)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/actions/test-and-report/action.yml
+++ b/.github/actions/test-and-report/action.yml
@@ -68,7 +68,11 @@ inputs:
     required: false
     default: ""
   deployment_service_account_name:
-    description: "Service account name from deployment (from deploy action)"
+    description: "API server service account name for auth token generation (from deploy action)"
+    required: false
+    default: ""
+  pipeline_runner_service_account_name:
+    description: "Pipeline runner service account for workflow execution (from deploy action)"
     required: false
     default: ""
   deployment_mode:
@@ -123,6 +127,7 @@ runs:
         INPUT_MULTI_USER: ${{ inputs.multi_user }}
         INPUT_SERVICE_ACCOUNT_NAME: ${{ inputs.service_account_name }}
         INPUT_DEPLOYMENT_SERVICE_ACCOUNT_NAME: ${{ inputs.deployment_service_account_name }}
+        INPUT_PIPELINE_RUNNER_SERVICE_ACCOUNT_NAME: ${{ inputs.pipeline_runner_service_account_name }}
         INPUT_DEPLOYMENT_NAME: ${{ inputs.deployment_name }}
         INPUT_DEFAULT_NAMESPACE: ${{ inputs.default_namespace }}
       run: |
@@ -148,23 +153,34 @@ runs:
           echo "🔍 Auto-detected API URL: $API_URL"
         fi
 
-        # Determine service account name (needed regardless of token source)
-        if [ -n "$INPUT_SERVICE_ACCOUNT_NAME" ]; then
-          SERVICE_ACCOUNT_NAME="$INPUT_SERVICE_ACCOUNT_NAME"
-          echo "ℹ️  Using provided service account: $SERVICE_ACCOUNT_NAME"
-        elif [ -n "$INPUT_DEPLOYMENT_SERVICE_ACCOUNT_NAME" ]; then
-          SERVICE_ACCOUNT_NAME="$INPUT_DEPLOYMENT_SERVICE_ACCOUNT_NAME"
-          echo "🔍 Using deployment service account: $SERVICE_ACCOUNT_NAME"
+        # Resolve AUTH_SERVICE_ACCOUNT: used for API token generation.
+        # Priority: deployment SA > deployment name > fallback.
+        if [ -n "$INPUT_DEPLOYMENT_SERVICE_ACCOUNT_NAME" ]; then
+          AUTH_SERVICE_ACCOUNT="$INPUT_DEPLOYMENT_SERVICE_ACCOUNT_NAME"
+          echo "🔍 Auth service account (from deployment): $AUTH_SERVICE_ACCOUNT"
         else
-          # Fallback based on deployment name
           DEPLOYMENT_NAME="${INPUT_DEPLOYMENT_NAME:-}"
           if [ -n "$DEPLOYMENT_NAME" ]; then
-            SERVICE_ACCOUNT_NAME="$DEPLOYMENT_NAME"
-            echo "🔍 Using deployment name as service account: $SERVICE_ACCOUNT_NAME"
+            AUTH_SERVICE_ACCOUNT="$DEPLOYMENT_NAME"
+            echo "🔍 Auth service account (from deployment name): $AUTH_SERVICE_ACCOUNT"
           else
-            SERVICE_ACCOUNT_NAME="ml-pipeline"  # Final fallback
-            echo "⚠️  Using fallback service account: $SERVICE_ACCOUNT_NAME"
+            AUTH_SERVICE_ACCOUNT="ml-pipeline"
+            echo "⚠️  Auth service account (fallback): $AUTH_SERVICE_ACCOUNT"
           fi
+        fi
+
+        # Resolve EXECUTION_SERVICE_ACCOUNT: used for ginkgo -serviceAccountName
+        # (the SA that pipeline runs execute under).
+        # Priority: explicit override > pipeline runner SA > default.
+        if [ -n "$INPUT_SERVICE_ACCOUNT_NAME" ]; then
+          EXECUTION_SERVICE_ACCOUNT="$INPUT_SERVICE_ACCOUNT_NAME"
+          echo "ℹ️  Execution service account (override): $EXECUTION_SERVICE_ACCOUNT"
+        elif [ -n "$INPUT_PIPELINE_RUNNER_SERVICE_ACCOUNT_NAME" ]; then
+          EXECUTION_SERVICE_ACCOUNT="$INPUT_PIPELINE_RUNNER_SERVICE_ACCOUNT_NAME"
+          echo "🔍 Execution service account (pipeline runner): $EXECUTION_SERVICE_ACCOUNT"
+        else
+          EXECUTION_SERVICE_ACCOUNT="pipeline-runner"
+          echo "⚠️  Execution service account (fallback): $EXECUTION_SERVICE_ACCOUNT"
         fi
 
         # Use provided token if available, otherwise generate from service account
@@ -193,9 +209,9 @@ runs:
             done
           fi
 
-          # Generate API token
-          echo "🔑 Generating token for $SERVICE_ACCOUNT_NAME..."
-          API_TOKEN=$(kubectl create token "$SERVICE_ACCOUNT_NAME" --namespace "$DEFAULT_NAMESPACE" --duration=60m)
+          # Generate API token from the auth SA (not the pipeline runner SA)
+          echo "🔑 Generating token for $AUTH_SERVICE_ACCOUNT..."
+          API_TOKEN=$(kubectl create token "$AUTH_SERVICE_ACCOUNT" --namespace "$DEFAULT_NAMESPACE" --duration=60m)
           if [ $? -eq 0 ]; then
             echo "✅ Token generated successfully"
           else
@@ -210,7 +226,7 @@ runs:
         fi
         echo "API_URL=$API_URL" >> "$GITHUB_OUTPUT"
         echo "API_TOKEN=$API_TOKEN" >> "$GITHUB_OUTPUT"
-        echo "SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-${INPUT_SERVICE_ACCOUNT_NAME:-}}" >> "$GITHUB_OUTPUT"
+        echo "SERVICE_ACCOUNT_NAME=${EXECUTION_SERVICE_ACCOUNT}" >> "$GITHUB_OUTPUT"
 
     - name: Run Tests
       id: run-tests

--- a/.github/workflows/api-server-tests.yml
+++ b/.github/workflows/api-server-tests.yml
@@ -169,6 +169,7 @@ jobs:
           # Deployment metadata from deploy action
           deployment_name: ${{ steps.deploy.outputs.deployment_name }}
           deployment_service_account_name: ${{ steps.deploy.outputs.service_account_name }}
+          pipeline_runner_service_account_name: ${{ steps.deploy.outputs.pipeline_runner_service_account }}
           deployment_mode: ${{ steps.deploy.outputs.deployment_mode }}
 
   api-test-k8s-native:
@@ -235,6 +236,7 @@ jobs:
           # Deployment metadata from deploy action
           deployment_name: ${{ steps.deploy.outputs.deployment_name }}
           deployment_service_account_name: ${{ steps.deploy.outputs.service_account_name }}
+          pipeline_runner_service_account_name: ${{ steps.deploy.outputs.pipeline_runner_service_account }}
           deployment_mode: ${{ steps.deploy.outputs.deployment_mode }}
 
   api-test-multi-user:
@@ -289,4 +291,5 @@ jobs:
           # Deployment metadata from deploy action
           deployment_name: ${{ steps.deploy.outputs.deployment_name }}
           deployment_service_account_name: ${{ steps.deploy.outputs.service_account_name }}
+          pipeline_runner_service_account_name: ${{ steps.deploy.outputs.pipeline_runner_service_account }}
           deployment_mode: ${{ steps.deploy.outputs.deployment_mode }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -207,6 +207,7 @@ jobs:
           ca_cert_path: ${{ env.CA_CERT_PATH }}
           deployment_name: ${{ steps.deploy.outputs.deployment_name }}
           deployment_service_account_name: ${{ steps.deploy.outputs.service_account_name }}
+          pipeline_runner_service_account_name: ${{ steps.deploy.outputs.pipeline_runner_service_account }}
           deployment_mode: ${{ steps.deploy.outputs.deployment_mode }}
 
   end-to-end-critical-scenario-multi-user-tests:
@@ -304,4 +305,5 @@ jobs:
           report_name: "E2EMultiUserTests_K8s=${{ matrix.k8s_version }}_cacheEnabled=${{ matrix.cache_enabled }}_multiUser=${{ matrix.multi_user }}_artifactProxy=${{ matrix.artifact_proxy }}"
           deployment_name: ${{ steps.deploy.outputs.deployment_name }}
           deployment_service_account_name: ${{ steps.deploy.outputs.service_account_name }}
+          pipeline_runner_service_account_name: ${{ steps.deploy.outputs.pipeline_runner_service_account }}
           deployment_mode: ${{ steps.deploy.outputs.deployment_mode }}

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -104,6 +104,7 @@ jobs:
           # Deployment metadata from deploy-release action
           deployment_name: ${{ steps.deploy-release.outputs.deployment_name }}
           deployment_service_account_name: ${{ steps.deploy-release.outputs.service_account_name }}
+          pipeline_runner_service_account_name: ${{ steps.deploy-release.outputs.pipeline_runner_service_account }}
           deployment_mode: ${{ steps.deploy-release.outputs.deployment_mode }}
 
       - name: Deploy from Branch
@@ -133,4 +134,5 @@ jobs:
           # Deployment metadata from deploy action
           deployment_name: ${{ steps.deploy.outputs.deployment_name }}
           deployment_service_account_name: ${{ steps.deploy.outputs.service_account_name }}
+          pipeline_runner_service_account_name: ${{ steps.deploy.outputs.pipeline_runner_service_account }}
           deployment_mode: ${{ steps.deploy.outputs.deployment_mode }}


### PR DESCRIPTION
**Description of your changes:**
Direct (non-operator) deployment outputs `ml-pipeline` as the service account for test pipeline runs. This SA lacks `configmaps` RBAC, causing the driver to fail when reading the `kfp-launcher` ConfigMap:

```
configmaps "kfp-launcher" is forbidden: User "system:serviceaccount:kubeflow:ml-pipeline"
cannot get resource "configmaps" in API group "" in the namespace "kubeflow"
```

The `pipeline-runner` SA has the correct permissions. In operator mode a single SA covers both roles, but in direct mode they are separate (`ml-pipeline` for the API server, `pipeline-runner` for workflow execution).

**Change:** `dspa_deployer.py` → output `pipeline-runner` instead of `ml-pipeline` as `SERVICE_ACCOUNT_NAME` for non-operator deployment.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [x] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment now exposes an additional "pipeline runner" service account identifier in deployment metadata and action outputs.
  * CI/test actions and workflows forward this new identifier to test steps so execution uses the intended service account.
* **Tests**
  * Added tests to validate the presence and consistency of the new deployment metadata keys across modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->