### PR TITLE
UPSTREAM<carry>: ci: ensure cert-manager webhook readiness in deployment script

### DIFF
--- a/.github/resources/scripts/deploy-kfp.sh
+++ b/.github/resources/scripts/deploy-kfp.sh
@@ -109,6 +109,38 @@ if [ "${PIPELINES_STORE}" == "kubernetes" ] || [ "${POD_TO_POD_TLS_ENABLED}" == 
     echo "Failed to deploy cert-manager."
     exit $EXIT_CODE
   fi
+
+  # The Makefile target waits for pods to be Ready, but the webhook may not
+  # be serving yet.  Wait for all three deployments so Certificate CRs
+  # applied later are accepted and processed.
+  kubectl wait --for=condition=available deployment/cert-manager-webhook -n cert-manager --timeout=120s
+  kubectl wait --for=condition=available deployment/cert-manager-cainjector -n cert-manager --timeout=120s
+
+  # Verify the webhook is actually serving by trying to create a test Issuer.
+  # Even after "Available", the webhook can briefly reject requests.
+  echo "Verifying cert-manager webhook is serving..."
+  for i in $(seq 1 12); do
+    if kubectl apply -f - <<'VERIFY_EOF'
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: cert-manager-readiness-probe
+  namespace: default
+spec:
+  selfSigned: {}
+VERIFY_EOF
+    then
+      kubectl delete issuer cert-manager-readiness-probe -n default --ignore-not-found
+      echo "cert-manager webhook is ready."
+      break
+    fi
+    if [ "$i" -eq 12 ]; then
+      echo "cert-manager webhook did not become ready in time."
+      exit 1
+    fi
+    echo "  Waiting for cert-manager webhook (attempt $i/12)..."
+    sleep 10
+  done
 fi
 
 

--- a/.github/resources/scripts/deploy-kfp.sh
+++ b/.github/resources/scripts/deploy-kfp.sh
@@ -110,27 +110,29 @@ if [ "${PIPELINES_STORE}" == "kubernetes" ] || [ "${POD_TO_POD_TLS_ENABLED}" == 
     exit $EXIT_CODE
   fi
 
-  # The Makefile target waits for pods to be Ready, but the webhook may not
-  # be serving yet.  Wait for all three deployments so Certificate CRs
-  # applied later are accepted and processed.
+  # The install-cert-manager target already waits for the main cert-manager
+  # deployment. Wait here for the remaining deployments, especially the
+  # webhook, so Certificate CRs applied later are accepted and processed.
   kubectl wait --for=condition=available deployment/cert-manager-webhook -n cert-manager --timeout=120s
   kubectl wait --for=condition=available deployment/cert-manager-cainjector -n cert-manager --timeout=120s
 
   # Verify the webhook is actually serving by trying to create a test Issuer.
   # Even after "Available", the webhook can briefly reject requests.
   echo "Verifying cert-manager webhook is serving..."
+  CERT_MANAGER_PROBE_NAMESPACE="cert-manager"
+  CERT_MANAGER_PROBE_NAME="cert-manager-readiness-probe-$$"
   for i in $(seq 1 12); do
-    if kubectl apply -f - <<'VERIFY_EOF'
+    if kubectl apply -f - <<VERIFY_EOF
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: cert-manager-readiness-probe
-  namespace: default
+  name: ${CERT_MANAGER_PROBE_NAME}
+  namespace: ${CERT_MANAGER_PROBE_NAMESPACE}
 spec:
   selfSigned: {}
 VERIFY_EOF
     then
-      kubectl delete issuer cert-manager-readiness-probe -n default --ignore-not-found
+      kubectl delete issuer "${CERT_MANAGER_PROBE_NAME}" -n "${CERT_MANAGER_PROBE_NAMESPACE}" --ignore-not-found || true
       echo "cert-manager webhook is ready."
       break
     fi


### PR DESCRIPTION
**Description of your changes:**
Resolves https://redhat.atlassian.net/browse/RHOAIENG-60048

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [x] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cert-manager deployment reliability by adding verification checks to ensure the service is fully operational before completing installation, with automated retry logic for robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->