### PR TITLE
UPSTREAM<carry>: Fixed cross-platform image builds

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -1,0 +1,55 @@
+name: Build images (arm64)
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - backend/Dockerfile
+      - backend/Dockerfile.driver
+      - backend/Dockerfile.launcher
+      - backend/Dockerfile.persistenceagent
+      - backend/Dockerfile.scheduledworkflow
+      - backend/Makefile
+      - go.mod
+      - go.sum
+      - .github/workflows/build-arm64.yml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+jobs:
+  build:
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: apiserver
+            make_target: image_apiserver
+            img_tag_var: IMG_TAG_APISERVER
+          - image: driver
+            make_target: image_driver
+            img_tag_var: IMG_TAG_DRIVER
+          - image: launcher
+            make_target: image_launcher
+            img_tag_var: IMG_TAG_LAUNCHER
+          - image: persistenceagent
+            make_target: image_persistence_agent
+            img_tag_var: IMG_TAG_PERSISTENCEAGENT
+          - image: scheduledworkflow
+            make_target: image_swf
+            img_tag_var: IMG_TAG_SCHEDULEDWORKFLOW
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Build ${{ matrix.image }} (cross-compile to amd64)
+        run: make -C backend ${{ matrix.make_target }} BUILDER_ARCH=arm64 TARGETARCH=amd64 ${{ matrix.img_tag_var }}=localhost/${{ matrix.image }}:amd64
+      - name: Verify amd64 image architecture
+        run: |
+          arch=$(docker inspect localhost/${{ matrix.image }}:amd64 --format '{{.Architecture}}')
+          echo "Image architecture: $arch"
+          [ "$arch" = "amd64" ] || { echo "Expected amd64, got $arch"; exit 1; }

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -26,30 +26,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - image: apiserver
+        image:
+          - name: apiserver
             make_target: image_apiserver
             img_tag_var: IMG_TAG_APISERVER
-          - image: driver
+          - name: driver
             make_target: image_driver
             img_tag_var: IMG_TAG_DRIVER
-          - image: launcher
+          - name: launcher
             make_target: image_launcher
             img_tag_var: IMG_TAG_LAUNCHER
-          - image: persistenceagent
+          - name: persistenceagent
             make_target: image_persistence_agent
             img_tag_var: IMG_TAG_PERSISTENCEAGENT
-          - image: scheduledworkflow
+          - name: scheduledworkflow
             make_target: image_swf
             img_tag_var: IMG_TAG_SCHEDULEDWORKFLOW
+        target_arch: [amd64, arm64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Build ${{ matrix.image }} (cross-compile to amd64)
-        run: make -C backend ${{ matrix.make_target }} BUILDER_ARCH=arm64 TARGETARCH=amd64 ${{ matrix.img_tag_var }}=localhost/${{ matrix.image }}:amd64
-      - name: Verify amd64 image architecture
+      - name: Build ${{ matrix.image.name }} (${{ matrix.target_arch }})
+        run: make -C backend ${{ matrix.image.make_target }} BUILDER_ARCH=arm64 TARGETARCH=${{ matrix.target_arch }} ${{ matrix.image.img_tag_var }}=localhost/${{ matrix.image.name }}:${{ matrix.target_arch }}
+      - name: Verify ${{ matrix.target_arch }} image architecture
         run: |
-          arch=$(docker inspect localhost/${{ matrix.image }}:amd64 --format '{{.Architecture}}')
+          arch=$(docker inspect localhost/${{ matrix.image.name }}:${{ matrix.target_arch }} --format '{{.Architecture}}')
           echo "Image architecture: $arch"
-          [ "$arch" = "amd64" ] || { echo "Expected amd64, got $arch"; exit 1; }
+          [ "$arch" = "${{ matrix.target_arch }}" ] || { echo "Expected ${{ matrix.target_arch }}, got $arch"; exit 1; }

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,8 +16,11 @@
 ARG SOURCE_CODE=.
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
+ARG BUILDER_ARCH=multiarch
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:d36470d5258da00f618b7aca9bdaab8e05134aa938bd6c42d9bd17d50ed45e76 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:45bd06d392349dfdb09073514cfebcc5082db33301347b51dcae8e5516a89126 AS go-toolset-multiarch
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:3880436381044c6d89c2311f2a7dc8d64224668bf84b43810982b5a9ddd851d0 AS go-toolset-arm64
+FROM go-toolset-${BUILDER_ARCH} AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -39,7 +42,7 @@ RUN GOTOOLCHAIN=local GO111MODULE=on CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TAR
       go build -tags no_openssl -o /bin/apiserver ./backend/src/apiserver/
 
 # 2. Compile preloaded pipeline samples
-FROM registry.access.redhat.com/ubi9/python-311 AS compiler
+FROM --platform=${BUILDPLATFORM:-linux/amd64} registry.access.redhat.com/ubi9/python-311 AS compiler
 
 ARG TARGETOS TARGETARCH
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -44,7 +44,7 @@ RUN GOTOOLCHAIN=local GO111MODULE=on CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TAR
 # 2. Compile preloaded pipeline samples
 FROM --platform=${BUILDPLATFORM:-linux/amd64} registry.access.redhat.com/ubi9/python-311 AS compiler
 
-ARG TARGETOS TARGETARCH
+ARG BUILDARCH=amd64
 
 USER root
 RUN dnf install -y python3-setuptools jq
@@ -54,10 +54,10 @@ RUN python3 -m pip install -r requirements.txt --no-cache-dir
 
 # Downloading Argo CLI so that the samples are validated
 ENV ARGO_VERSION=v3.6.7
-RUN curl -sLO https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-${TARGETOS:-linux}-${TARGETARCH:-amd64}.gz && \
-    gunzip argo-${TARGETOS:-linux}-${TARGETARCH:-amd64}.gz && \
-    chmod +x argo-${TARGETOS:-linux}-${TARGETARCH:-amd64} && \
-    mv ./argo-${TARGETOS:-linux}-${TARGETARCH:-amd64} /usr/local/bin/argo
+RUN curl -sLO https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-${BUILDARCH:-amd64}.gz && \
+    gunzip argo-linux-${BUILDARCH:-amd64}.gz && \
+    chmod +x argo-linux-${BUILDARCH:-amd64} && \
+    mv ./argo-linux-${BUILDARCH:-amd64} /usr/local/bin/argo
 
 WORKDIR /
 COPY ./samples /samples

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -42,9 +42,9 @@ RUN GOTOOLCHAIN=local GO111MODULE=on CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TAR
       go build -tags no_openssl -o /bin/apiserver ./backend/src/apiserver/
 
 # 2. Compile preloaded pipeline samples
-FROM --platform=${BUILDPLATFORM:-linux/amd64} registry.access.redhat.com/ubi9/python-311 AS compiler
+FROM registry.access.redhat.com/ubi9/python-311 AS compiler
 
-ARG BUILDARCH=amd64
+ARG TARGETOS TARGETARCH
 
 USER root
 RUN dnf install -y python3-setuptools jq
@@ -54,10 +54,10 @@ RUN python3 -m pip install -r requirements.txt --no-cache-dir
 
 # Downloading Argo CLI so that the samples are validated
 ENV ARGO_VERSION=v3.6.7
-RUN curl -sLO https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-${BUILDARCH:-amd64}.gz && \
-    gunzip argo-linux-${BUILDARCH:-amd64}.gz && \
-    chmod +x argo-linux-${BUILDARCH:-amd64} && \
-    mv ./argo-linux-${BUILDARCH:-amd64} /usr/local/bin/argo
+RUN curl -sLO https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-${TARGETOS:-linux}-${TARGETARCH:-amd64}.gz && \
+    gunzip argo-${TARGETOS:-linux}-${TARGETARCH:-amd64}.gz && \
+    chmod +x argo-${TARGETOS:-linux}-${TARGETARCH:-amd64} && \
+    mv ./argo-${TARGETOS:-linux}-${TARGETARCH:-amd64} /usr/local/bin/argo
 
 WORKDIR /
 COPY ./samples /samples

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,10 +22,16 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:45bd06d392349dfdb0
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:3880436381044c6d89c2311f2a7dc8d64224668bf84b43810982b5a9ddd851d0 AS go-toolset-arm64
 FROM go-toolset-${BUILDER_ARCH} AS builder
 
+ARG SOURCE_CODE
 ARG TARGETOS
 ARG TARGETARCH
 
 USER root
+
+ENV ZIG_VERSION=0.16.0
+RUN ARCH=$(uname -m) && \
+    curl -sL "https://ziglang.org/download/${ZIG_VERSION}/zig-${ARCH}-linux-${ZIG_VERSION}.tar.xz" | tar -xJ -C /usr/local && \
+    ln -s /usr/local/zig-${ARCH}-linux-${ZIG_VERSION}/zig /usr/local/bin/zig
 
 COPY ${SOURCE_CODE}/go.mod ./
 COPY ${SOURCE_CODE}/go.sum ./
@@ -37,12 +43,15 @@ RUN GOTOOLCHAIN=local GO111MODULE=on go mod download
 # Copy the source
 COPY ${SOURCE_CODE}/ ./
 
-RUN GOTOOLCHAIN=local GO111MODULE=on CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+RUN CC="zig cc --target=$([ "${TARGETARCH}" = "arm64" ] && echo aarch64 || echo x86_64)-linux-gnu" && \
+    GOTOOLCHAIN=local GO111MODULE=on CGO_ENABLED=1 CC="${CC}" GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
       GOFIPS140=v1.0.0 \
       go build -tags no_openssl -o /bin/apiserver ./backend/src/apiserver/
 
 # 2. Compile preloaded pipeline samples
-FROM registry.access.redhat.com/ubi9/python-311 AS compiler
+FROM registry.access.redhat.com/ubi9/python-311@sha256:7b6cb58d3ff034df7b300800bd89a469d9bd2f739d43250d76b9c9e805307ab5 AS python-311-multiarch
+FROM registry.access.redhat.com/ubi9/python-311@sha256:c7622eed60c05b1f75a0d2f71b265148c2e07c8a53a7a4bc6ebdd7fbb2168da3 AS python-311-arm64
+FROM python-311-${BUILDER_ARCH} AS compiler
 
 ARG TARGETOS TARGETARCH
 
@@ -71,6 +80,12 @@ RUN set -e; \
     echo "Compiling: \"$pipeline_py\"" && python3 "$pipeline_py" && echo -n "Output: " && ls "$pipeline_py.yaml"; \
     done
 
+# 3. Install runtime dependencies on the build host architecture
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:865c6a875328a1174ff7f17599574412edd327aa47812951b9bead902806dc53 AS ubi-minimal-multiarch
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:da229086eb7881bb653e99ace537fc03512bbbfcf14024e7e447b48015d7cc8c AS ubi-minimal-arm64
+FROM ubi-minimal-${BUILDER_ARCH} AS runtime-deps
+RUN microdnf install -y ca-certificates wget && microdnf clean all
+
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 
 WORKDIR /bin
@@ -79,12 +94,8 @@ COPY --from=builder /opt/app-root/src/backend/src/apiserver/config/ /config
 COPY --from=builder /bin/apiserver /bin/apiserver
 
 COPY --from=compiler /samples/ /samples/
-RUN chmod +x /bin/apiserver
-
-USER root
-
-# Adding CA certificate so API server can download pipeline through URL and wget is used for liveness/readiness probe command
-RUN microdnf install -y ca-certificates wget
+COPY --from=runtime-deps /etc/pki /etc/pki
+COPY --from=runtime-deps /usr/bin/wget /usr/bin/wget
 
 USER 1001
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,9 +28,18 @@ ARG TARGETARCH
 
 USER root
 
+# Zig is used as a C cross-compiler for CGO (required by mattn/go-sqlite3).
+# Unlike gcc, Zig can target any architecture via --target without needing
+# separate cross-toolchains or a cross-linker.
 ENV ZIG_VERSION=0.16.0
+ENV ZIG_SHA256_x86_64=70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00
+ENV ZIG_SHA256_aarch64=ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17
 RUN ARCH=$(uname -m) && \
-    curl -sL "https://ziglang.org/download/${ZIG_VERSION}/zig-${ARCH}-linux-${ZIG_VERSION}.tar.xz" | tar -xJ -C /usr/local && \
+    eval "EXPECTED=\$ZIG_SHA256_${ARCH}" && \
+    curl --fail -sL "https://ziglang.org/download/${ZIG_VERSION}/zig-${ARCH}-linux-${ZIG_VERSION}.tar.xz" -o /tmp/zig.tar.xz && \
+    echo "${EXPECTED}  /tmp/zig.tar.xz" | sha256sum -c - && \
+    tar -xJ -C /usr/local -f /tmp/zig.tar.xz && \
+    rm /tmp/zig.tar.xz && \
     ln -s /usr/local/zig-${ARCH}-linux-${ZIG_VERSION}/zig /usr/local/bin/zig
 
 COPY ${SOURCE_CODE}/go.mod ./
@@ -43,7 +52,12 @@ RUN GOTOOLCHAIN=local GO111MODULE=on go mod download
 # Copy the source
 COPY ${SOURCE_CODE}/ ./
 
-RUN CC="zig cc --target=$([ "${TARGETARCH}" = "arm64" ] && echo aarch64 || echo x86_64)-linux-gnu" && \
+RUN case "${TARGETARCH}" in \
+      amd64) ZIG_TARGET="x86_64-linux-gnu" ;; \
+      arm64) ZIG_TARGET="aarch64-linux-gnu" ;; \
+      *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    CC="zig cc --target=${ZIG_TARGET}" && \
     GOTOOLCHAIN=local GO111MODULE=on CGO_ENABLED=1 CC="${CC}" GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
       GOFIPS140=v1.0.0 \
       go build -tags no_openssl -o /bin/apiserver ./backend/src/apiserver/

--- a/backend/Dockerfile.driver
+++ b/backend/Dockerfile.driver
@@ -16,9 +16,11 @@
 ARG SOURCE_CODE=.
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
+ARG BUILDER_ARCH=multiarch
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:d36470d5258da00f618b7aca9bdaab8e05134aa938bd6c42d9bd17d50ed45e76 AS builder
-
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:45bd06d392349dfdb09073514cfebcc5082db33301347b51dcae8e5516a89126 AS go-toolset-multiarch
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:3880436381044c6d89c2311f2a7dc8d64224668bf84b43810982b5a9ddd851d0 AS go-toolset-arm64
+FROM go-toolset-${BUILDER_ARCH} AS builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.driver
+++ b/backend/Dockerfile.driver
@@ -49,7 +49,6 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 WORKDIR /bin
 
 COPY --from=builder /bin/driver /bin/driver
-RUN chmod +x /bin/driver
 
 USER 65534
 

--- a/backend/Dockerfile.launcher
+++ b/backend/Dockerfile.launcher
@@ -50,7 +50,6 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 WORKDIR /bin
 
 COPY --from=builder /bin/launcher-v2 /bin/launcher-v2
-RUN chmod +x /bin/launcher-v2
 
 USER 65534
 

--- a/backend/Dockerfile.launcher
+++ b/backend/Dockerfile.launcher
@@ -17,10 +17,11 @@ ARG SOURCE_CODE=.
 ARG CI_CONTAINER_VERSION="unknown"
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
+ARG BUILDER_ARCH=multiarch
 
-
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:d36470d5258da00f618b7aca9bdaab8e05134aa938bd6c42d9bd17d50ed45e76 AS builder
-
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:45bd06d392349dfdb09073514cfebcc5082db33301347b51dcae8e5516a89126 AS go-toolset-multiarch
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:3880436381044c6d89c2311f2a7dc8d64224668bf84b43810982b5a9ddd851d0 AS go-toolset-arm64
+FROM go-toolset-${BUILDER_ARCH} AS builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.persistenceagent
+++ b/backend/Dockerfile.persistenceagent
@@ -17,8 +17,11 @@ ARG SOURCE_CODE=.
 ARG CI_CONTAINER_VERSION="unknown"
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
+ARG BUILDER_ARCH=multiarch
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:d36470d5258da00f618b7aca9bdaab8e05134aa938bd6c42d9bd17d50ed45e76 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:45bd06d392349dfdb09073514cfebcc5082db33301347b51dcae8e5516a89126 AS go-toolset-multiarch
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:3880436381044c6d89c2311f2a7dc8d64224668bf84b43810982b5a9ddd851d0 AS go-toolset-arm64
+FROM go-toolset-${BUILDER_ARCH} AS builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -51,8 +51,7 @@ RUN GOTOOLCHAIN=local GO111MODULE=on CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TAR
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:865c6a875328a1174ff7f17599574412edd327aa47812951b9bead902806dc53 AS ubi-minimal-multiarch
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:da229086eb7881bb653e99ace537fc03512bbbfcf14024e7e447b48015d7cc8c AS ubi-minimal-arm64
 FROM ubi-minimal-${BUILDER_ARCH} AS runtime-deps
-RUN microdnf makecache && \
-     microdnf install -y tzdata.noarch && microdnf clean all
+RUN microdnf install -y tzdata.noarch && microdnf clean all
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 

--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -16,8 +16,11 @@
 ARG SOURCE_CODE=.
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
+ARG BUILDER_ARCH=multiarch
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:d36470d5258da00f618b7aca9bdaab8e05134aa938bd6c42d9bd17d50ed45e76 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:45bd06d392349dfdb09073514cfebcc5082db33301347b51dcae8e5516a89126 AS go-toolset-multiarch
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:3880436381044c6d89c2311f2a7dc8d64224668bf84b43810982b5a9ddd851d0 AS go-toolset-arm64
+FROM go-toolset-${BUILDER_ARCH} AS builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -48,15 +48,18 @@ RUN GOTOOLCHAIN=local GO111MODULE=on CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TAR
       GOFIPS140=v1.0.0 \
       go build -tags no_openssl -o /bin/controller backend/src/crd/controller/scheduledworkflow/*.go
 
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:865c6a875328a1174ff7f17599574412edd327aa47812951b9bead902806dc53 AS ubi-minimal-multiarch
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:da229086eb7881bb653e99ace537fc03512bbbfcf14024e7e447b48015d7cc8c AS ubi-minimal-arm64
+FROM ubi-minimal-${BUILDER_ARCH} AS runtime-deps
+RUN microdnf makecache && \
+     microdnf install -y tzdata.noarch && microdnf clean all
+
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 
 WORKDIR /bin
 
 COPY --from=builder /bin/controller /bin/controller
-RUN chmod +x /bin/controller
-
-RUN microdnf makecache && \
-     microdnf install -y tzdata.noarch
+COPY --from=runtime-deps /usr/share/zoneinfo /usr/share/zoneinfo
 
 ENV NAMESPACE=""
 ENV LOG_LEVEL=info

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -9,6 +9,12 @@ CERT_MANAGER_VERSION ?= v1.16.2
 # Default is amd64.
 TARGETARCH ?= amd64
 
+# BUILDER_ARCH selects the builder stage platform in the Dockerfile (multiarch or arm64).
+# Default is multiarch for production builds on Linux.
+# Mac users must set BUILDER_ARCH=arm64 for local development because the
+# multiarch image segfaults under QEMU emulation on Apple Silicon.
+BUILDER_ARCH ?= multiarch
+
 PLATFORM_FLAG ?= --platform linux/$(TARGETARCH)
 
 # Container Build Params
@@ -46,25 +52,25 @@ image_all: image_apiserver image_persistence_agent image_cache image_swf image_v
 
 .PHONY: image_apiserver
 image_apiserver:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg TARGETARCH=$(TARGETARCH) -t ${IMG_REGISTRY}${IMG_TAG_APISERVER} -f backend/Dockerfile .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg TARGETARCH=$(TARGETARCH) --build-arg BUILDER_ARCH=$(BUILDER_ARCH) -t ${IMG_REGISTRY}${IMG_TAG_APISERVER} -f backend/Dockerfile .
 .PHONY: image_persistence_agent
 image_persistence_agent:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg TARGETARCH=$(TARGETARCH) -t ${IMG_REGISTRY}${IMG_TAG_PERSISTENCEAGENT} -f backend/Dockerfile.persistenceagent .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg TARGETARCH=$(TARGETARCH) --build-arg BUILDER_ARCH=$(BUILDER_ARCH) -t ${IMG_REGISTRY}${IMG_TAG_PERSISTENCEAGENT} -f backend/Dockerfile.persistenceagent .
 .PHONY: image_cache
 image_cache:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg TARGETARCH=$(TARGETARCH) -t ${IMG_REGISTRY}${IMG_TAG_CACHESERVER} -f backend/Dockerfile.cacheserver .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg TARGETARCH=$(TARGETARCH) --build-arg BUILDER_ARCH=$(BUILDER_ARCH) -t ${IMG_REGISTRY}${IMG_TAG_CACHESERVER} -f backend/Dockerfile.cacheserver .
 .PHONY: image_swf
 image_swf:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg TARGETARCH=$(TARGETARCH) -t ${IMG_REGISTRY}${IMG_TAG_SCHEDULEDWORKFLOW} -f backend/Dockerfile.scheduledworkflow .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg TARGETARCH=$(TARGETARCH) --build-arg BUILDER_ARCH=$(BUILDER_ARCH) -t ${IMG_REGISTRY}${IMG_TAG_SCHEDULEDWORKFLOW} -f backend/Dockerfile.scheduledworkflow .
 .PHONY: image_viewer
 image_viewer:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg TARGETARCH=$(TARGETARCH) -t ${IMG_REGISTRY}${IMG_TAG_VIEWERCONTROLLER} -f backend/Dockerfile.viewercontroller .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg TARGETARCH=$(TARGETARCH) --build-arg BUILDER_ARCH=$(BUILDER_ARCH) -t ${IMG_REGISTRY}${IMG_TAG_VIEWERCONTROLLER} -f backend/Dockerfile.viewercontroller .
 .PHONY: image_visualization
 image_visualization:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) -t ${IMG_REGISTRY}${IMG_TAG_VISUALIZATION} -f backend/Dockerfile.visualization .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg BUILDER_ARCH=$(BUILDER_ARCH) -t ${IMG_REGISTRY}${IMG_TAG_VISUALIZATION} -f backend/Dockerfile.visualization .
 .PHONY: image_driver
 image_driver:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg TARGETARCH=$(TARGETARCH) -t ${IMG_REGISTRY}${IMG_TAG_DRIVER} -f backend/Dockerfile.driver .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg TARGETARCH=$(TARGETARCH) --build-arg BUILDER_ARCH=$(BUILDER_ARCH) -t ${IMG_REGISTRY}${IMG_TAG_DRIVER} -f backend/Dockerfile.driver .
 .PHONY: image_driver_debug
 image_driver_debug:
 	cd $(MOD_ROOT) && sed -e '/RUN .*go mod download/a\
@@ -74,10 +80,10 @@ image_driver_debug:
 	COPY --from=builder /go/bin/dlv /bin/dlv\
 	EXPOSE 2345' \
 	backend/Dockerfile.driver > backend/Dockerfile.driver-debug
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg GCFLAGS="all=-N -l" --build-arg TARGETARCH=$(TARGETARCH) -t ${IMG_REGISTRY}${IMG_TAG_DRIVER}:debug -f backend/Dockerfile.driver-debug .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg GCFLAGS="all=-N -l" --build-arg TARGETARCH=$(TARGETARCH) --build-arg BUILDER_ARCH=$(BUILDER_ARCH) -t ${IMG_REGISTRY}${IMG_TAG_DRIVER}:debug -f backend/Dockerfile.driver-debug .
 .PHONY: image_launcher
 image_launcher:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg TARGETARCH=$(TARGETARCH) -t ${IMG_REGISTRY}${IMG_TAG_LAUNCHER} -f backend/Dockerfile.launcher .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build $(PLATFORM_FLAG) --build-arg TARGETARCH=$(TARGETARCH) --build-arg BUILDER_ARCH=$(BUILDER_ARCH) -t ${IMG_REGISTRY}${IMG_TAG_LAUNCHER} -f backend/Dockerfile.launcher .
 
 .PHONY: install-cert-manager
 install-cert-manager:


### PR DESCRIPTION
**Description of your changes:**

Enables cross-platform Docker image builds for all 5 backend images (apiserver, driver, launcher, persistenceagent, scheduledworkflow) on Apple Silicon and arm64 CI runners.

### Approach

Replaces the previous `--platform=$BUILDPLATFORM` approach with a `BUILDER_ARCH` multi-stage pattern (same as [DSPO PR #1053](https://github.com/opendatahub-io/data-science-pipelines-operator/pull/1053)):

- **Per-architecture digest-pinned FROM lines** for `go-toolset`, `python-311`, and `ubi-minimal`, selected via `FROM go-toolset-${BUILDER_ARCH} AS builder` where `BUILDER_ARCH` is `multiarch` (amd64, default) or `arm64`.
- **Zig as a C cross-compiler** for the apiserver image, which is the only image requiring `CGO_ENABLED=1` (due to `mattn/go-sqlite3`). Zig handles both compilation and linking to any target architecture without needing separate cross-toolchains. The Zig tarball is SHA-256 verified.
- **No RUN commands in final Docker stages** — `microdnf install` calls are moved to intermediate `runtime-deps` stages and results are COPYed into the final image. This prevents `exec format error` when the final stage's platform differs from the build host.
- **Removed unnecessary `RUN chmod +x`** from driver, launcher, and scheduledworkflow final stages.

### Key details

| Image | CGO | Cross-compile method |
|-------|-----|---------------------|
| apiserver | `CGO_ENABLED=1` | Zig (`zig cc --target=...`) |
| driver | `CGO_ENABLED=0` | Native Go cross-compilation |
| launcher | `CGO_ENABLED=0` | Native Go cross-compilation |
| persistenceagent | `CGO_ENABLED=0` | Native Go cross-compilation |
| scheduledworkflow | `CGO_ENABLED=0` | Native Go cross-compilation |

### CI

New `.github/workflows/build-arm64.yml` workflow validates all 5 images for both `amd64` and `arm64` targets on `ubuntu-24.04-arm` runners, with architecture verification via `docker inspect`.

### Local usage (Apple Silicon)

```bash
# Build for arm64 (native)
make -C backend image_apiserver BUILDER_ARCH=arm64 TARGETARCH=arm64

# Build for amd64 (cross-compile)
make -C backend image_apiserver BUILDER_ARCH=arm64 TARGETARCH=amd64
```

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [x] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-architecture container build support for backend images, including arm64.
  * Added a new CI workflow that builds and verifies backend images on both amd64 and arm64.

* **Bug Fixes**
  * Improved runtime image packaging to reduce setup steps and make builds more consistent across architectures.
  * Updated image builds to use architecture-aware base stages and toolchains for more reliable cross-platform output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->