### PR TITLE
chore: sync upstream kubeflow/pipelines

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -46,6 +46,10 @@ const (
 	DefaultSecurityContextRunAsNonRoot      string = "DEFAULT_SECURITY_CONTEXT_RUN_AS_NON_ROOT"
 	BlockV1Pipelines                        string = "BLOCK_V1_PIPELINES"
 	V1NamespaceWhitelist                    string = "V1_ALLOWED_NAMESPACES"
+	PipelineURLAllowedDomains               string = "PIPELINE_URL_ALLOWED_DOMAINS"
+	PipelineURLAllowHTTP                    string = "PIPELINE_URL_ALLOW_HTTP"
+	PipelineURLTimeout                      string = "PIPELINE_URL_TIMEOUT"
+	PipelineURLValidationEnabled            string = "PIPELINE_URL_VALIDATION_ENABLED"
 )
 
 func IsPipelineVersionUpdatedByDefault() bool {

--- a/backend/src/apiserver/server/pipeline_server.go
+++ b/backend/src/apiserver/server/pipeline_server.go
@@ -16,11 +16,13 @@ package server
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 	"path"
 	"strings"
 
+	"github.com/golang/glog"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -200,8 +202,21 @@ func (s *BasePipelineServer) createPipelineAndPipelineVersion(ctx context.Contex
 	if err != nil {
 		return nil, nil, util.NewInvalidInputError("invalid pipeline spec URL: %v", pipelineURLStr)
 	}
+
+	if err := validation.ValidatePipelineURL(pipelineURL.String()); err != nil {
+		glog.Warningf("Pipeline URL validation failed: %v", err)
+		return nil, nil, util.NewInvalidInputError("Pipeline URL validation failed")
+	}
+
 	resp, err := s.httpClient.Get(pipelineURL.String())
 	if err != nil {
+		// Unwrap redirect validation errors so they return 4xx, not 500
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			if userErr, ok := urlErr.Err.(*util.UserError); ok {
+				return nil, nil, userErr
+			}
+		}
 		return nil, nil, util.NewInternalServerError(err, "error downloading the pipeline spec from %v", pipelineURL.String())
 	} else if resp.StatusCode != http.StatusOK {
 		return nil, nil, util.NewInvalidInputError("error fetching pipeline spec from %v - request returned %v", pipelineURL.String(), resp.Status)
@@ -704,7 +719,7 @@ func NewPipelineServer(resourceManager *resource.ResourceManager, options *Pipel
 	return &PipelineServer{
 		BasePipelineServer: &BasePipelineServer{
 			resourceManager: resourceManager,
-			httpClient:      http.DefaultClient,
+			httpClient:      validation.SafePipelineHTTPClient(),
 			options:         options,
 		},
 	}
@@ -714,7 +729,7 @@ func NewPipelineServerV1(resourceManager *resource.ResourceManager, options *Pip
 	return &PipelineServerV1{
 		BasePipelineServer: &BasePipelineServer{
 			resourceManager: resourceManager,
-			httpClient:      http.DefaultClient,
+			httpClient:      validation.SafePipelineHTTPClient(),
 			options:         options,
 		},
 	}
@@ -780,12 +795,22 @@ func (s *BasePipelineServer) createPipelineVersion(ctx context.Context, pv *mode
 		return nil, util.NewInvalidInputError("Failed to create a pipeline version due to invalid pipeline spec URI. PipelineSpecURI: %v. Please specify a valid URL", pv.PipelineSpecURI)
 	}
 
+	if err := validation.ValidatePipelineURL(pipelineUrl.String()); err != nil {
+		glog.Warningf("Pipeline URL validation failed: %v", err)
+		return nil, util.NewInvalidInputError("Pipeline URL validation failed")
+	}
 	resp, err := s.httpClient.Get(pipelineUrl.String())
-	if err != nil || resp.StatusCode != http.StatusOK {
-		if err == nil {
-			return nil, util.NewInvalidInputError("Failed to fetch pipeline spec with url: %v. Request returned %v", pipelineUrl.String(), resp.Status)
+	if err != nil {
+		// Unwrap redirect validation errors so they return 4xx, not 500
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			if userErr, ok := urlErr.Err.(*util.UserError); ok {
+				return nil, userErr
+			}
 		}
 		return nil, util.NewInternalServerError(err, "Failed to create a pipeline version due error downloading the pipeline spec from %v", pipelineUrl.String())
+	} else if resp.StatusCode != http.StatusOK {
+		return nil, util.NewInvalidInputError("Failed to fetch pipeline spec with url: %v. Request returned %v", pipelineUrl.String(), resp.Status)
 	}
 	defer resp.Body.Close()
 	pipelineFileName := path.Base(pipelineUrl.String())

--- a/backend/src/apiserver/server/pipeline_server_test.go
+++ b/backend/src/apiserver/server/pipeline_server_test.go
@@ -41,6 +41,12 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 )
 
+func TestMain(m *testing.M) {
+	// Disable URL validation for tests (allows mock server URLs)
+	viper.Set(common.PipelineURLValidationEnabled, "false")
+	os.Exit(m.Run())
+}
+
 func createPipelineServerV1(resourceManager *resource.ResourceManager, httpClient *http.Client) *PipelineServerV1 {
 	return &PipelineServerV1{
 		BasePipelineServer: &BasePipelineServer{
@@ -1234,4 +1240,94 @@ func TestCanAccessPipeline_SharedPipeline_ReadAllowed_EvenWhenUnauthorized(t *te
 	// LIST on shared pipeline should still be allowed even for unauthorized user
 	err = pipelineServer.canAccessPipeline(ctx, "", &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbList})
 	assert.Nil(t, err)
+}
+
+func TestCreatePipelineV1_URLValidation_BlocksDisallowedDomain(t *testing.T) {
+	// Enable URL validation for this test (overrides TestMain's global disable)
+	viper.Set(common.PipelineURLValidationEnabled, "true")
+	defer viper.Set(common.PipelineURLValidationEnabled, "false")
+
+	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	resourceManager := resource.NewResourceManager(clientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+
+	pipelineServer := createPipelineServerV1(resourceManager, http.DefaultClient)
+	_, err := pipelineServer.CreatePipelineV1(
+		context.Background(), &api.CreatePipelineRequest{
+			Pipeline: &api.Pipeline{
+				Url:  &api.Url{PipelineUrl: "https://evil.com/malicious.yaml"},
+				Name: "test-blocked-domain",
+			},
+		},
+	)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Pipeline URL validation failed")
+}
+
+func TestCreatePipelineV1_URLValidation_BlocksHTTPByDefault(t *testing.T) {
+	viper.Set(common.PipelineURLValidationEnabled, "true")
+	defer viper.Set(common.PipelineURLValidationEnabled, "false")
+
+	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	resourceManager := resource.NewResourceManager(clientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+
+	pipelineServer := createPipelineServerV1(resourceManager, http.DefaultClient)
+	_, err := pipelineServer.CreatePipelineV1(
+		context.Background(), &api.CreatePipelineRequest{
+			Pipeline: &api.Pipeline{
+				Url:  &api.Url{PipelineUrl: "http://storage.googleapis.com/bucket/file.yaml"},
+				Name: "test-http-blocked",
+			},
+		},
+	)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Pipeline URL validation failed")
+}
+
+func TestCreatePipelineV1_URLValidation_BlocksFileScheme(t *testing.T) {
+	viper.Set(common.PipelineURLValidationEnabled, "true")
+	defer viper.Set(common.PipelineURLValidationEnabled, "false")
+
+	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	resourceManager := resource.NewResourceManager(clientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+
+	pipelineServer := createPipelineServerV1(resourceManager, http.DefaultClient)
+	_, err := pipelineServer.CreatePipelineV1(
+		context.Background(), &api.CreatePipelineRequest{
+			Pipeline: &api.Pipeline{
+				Url:  &api.Url{PipelineUrl: "file:///etc/passwd"},
+				Name: "test-file-blocked",
+			},
+		},
+	)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Pipeline URL validation failed")
+}
+
+type errorRoundTripper struct {
+	err error
+}
+
+func (rt errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, rt.err
+}
+
+func TestCreatePipelineV1_URLValidation_MapsTransportValidationErrorToInvalidInput(t *testing.T) {
+	viper.Set(common.PipelineURLValidationEnabled, "false")
+
+	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	resourceManager := resource.NewResourceManager(clientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+
+	pipelineServer := createPipelineServerV1(resourceManager, &http.Client{
+		Transport: errorRoundTripper{err: util.NewInvalidInputError("connection to blocked IP range denied")},
+	})
+	_, err := pipelineServer.CreatePipelineV1(
+		context.Background(), &api.CreatePipelineRequest{
+			Pipeline: &api.Pipeline{
+				Url:  &api.Url{PipelineUrl: "https://storage.googleapis.com/bucket/file.yaml"},
+				Name: "test-transport-validation-error",
+			},
+		},
+	)
+	assert.NotNil(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
 }

--- a/backend/src/apiserver/validation/pipeline_url.go
+++ b/backend/src/apiserver/validation/pipeline_url.go
@@ -1,0 +1,255 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+)
+
+// Default allowed domains for pipeline URLs
+var defaultAllowedDomains = []string{
+	"storage.googleapis.com",
+	"s3.amazonaws.com",
+	"github.com",
+	"raw.githubusercontent.com",
+}
+
+// Blocked CIDRs - private/loopback/link-local/metadata
+var blockedCIDRs = []string{
+	// Loopback
+	"127.0.0.0/8",
+	"::1/128",
+
+	// Private
+	"10.0.0.0/8",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+	"fc00::/7",
+
+	// Link-local
+	"169.254.0.0/16",
+	"fe80::/10",
+
+	// Metadata
+	"169.254.169.254/32",
+	"fd00:ec2::254/128",
+
+	// Invalid
+	"0.0.0.0/8",
+	"::/128",
+}
+
+var defaultPorts = map[string]string{
+	"https": "443",
+	"http":  "80",
+}
+
+var (
+	blockedNets    []*net.IPNet
+	allowedDomains []*regexp.Regexp
+	urlConfigInit  sync.Once
+)
+
+// initURLConfig initializes blocked networks and allowed domains
+func initURLConfig() {
+	urlConfigInit.Do(func() {
+		// Parse CIDR strings into IPNet objects
+		for _, cidr := range blockedCIDRs {
+			if _, ipNet, err := net.ParseCIDR(cidr); err == nil {
+				blockedNets = append(blockedNets, ipNet)
+			} else {
+				glog.Warningf("Failed to parse blocked CIDR %q: %v", cidr, err)
+			}
+		}
+
+		// Build allowed domains: defaults + user-configured
+		allDomains := append([]string{}, defaultAllowedDomains...)
+		userDomains := common.GetStringConfigWithDefault(common.PipelineURLAllowedDomains, "")
+		if userDomains != "" {
+			for _, d := range strings.Split(userDomains, ",") {
+				if d = strings.TrimSpace(d); d != "" {
+					allDomains = append(allDomains, d)
+				}
+			}
+		}
+
+		// Compile domain patterns into regex
+		for _, domain := range allDomains {
+			pattern := "^" + strings.ReplaceAll(regexp.QuoteMeta(domain), "\\*", ".*") + "$"
+			if re, err := regexp.Compile(pattern); err == nil {
+				allowedDomains = append(allowedDomains, re)
+			} else {
+				glog.Warningf("Failed to compile domain pattern %q: %v", pattern, err)
+			}
+		}
+	})
+}
+
+// ValidatePipelineURL validates a pipeline URL is safe to fetch
+// Can be disabled via PIPELINE_URL_VALIDATION_ENABLED=false (for testing purposes only)
+func ValidatePipelineURL(urlStr string) error {
+	// Allow disabling validation
+	if !common.GetBoolConfigWithDefault(common.PipelineURLValidationEnabled, true) {
+		return nil
+	}
+
+	initURLConfig()
+
+	parsed, err := url.ParseRequestURI(urlStr)
+	if err != nil {
+		return util.NewInvalidInputError("invalid URL: %v", err)
+	}
+
+	// Validate scheme
+	allowHTTP := common.GetBoolConfigWithDefault(common.PipelineURLAllowHTTP, false)
+	if parsed.Scheme != "https" && (parsed.Scheme != "http" || !allowHTTP) {
+		return util.NewInvalidInputError("URL scheme %q not allowed, use https", parsed.Scheme)
+	}
+
+	// Validate port
+	port := parsed.Port()
+	if port != "" && port != defaultPorts[parsed.Scheme] {
+		return util.NewInvalidInputError(
+			"%s requires port %s, got %q",
+			strings.ToUpper(parsed.Scheme),
+			defaultPorts[parsed.Scheme],
+			port,
+		)
+	}
+
+	// Validate domain against allowlist
+	host := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
+	if !isDomainAllowed(host) {
+		return util.NewInvalidInputError("URL domain %q not in allowlist", host)
+	}
+
+	// Resolve DNS and validate IPs are not in blocked ranges
+	if err := validateResolvedIPs(host); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func isDomainAllowed(host string) bool {
+	for _, re := range allowedDomains {
+		if re.MatchString(host) {
+			return true
+		}
+	}
+	return false
+}
+
+const dnsLookupTimeout = 5 * time.Second
+
+func validateResolvedIPs(host string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), dnsLookupTimeout)
+	defer cancel()
+
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return util.NewInvalidInputError("DNS resolution failed for %q: %v", host, err)
+	}
+
+	for _, addr := range addrs {
+		if isBlockedIP(addr.IP) {
+			return util.NewInvalidInputError("URL resolves to blocked IP range: %v", addr.IP)
+		}
+	}
+	return nil
+}
+
+func isBlockedIP(ip net.IP) bool {
+	for _, ipNet := range blockedNets {
+		if ipNet.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// SafePipelineHTTPClient creates an HTTP client with timeout, redirect validation,
+// and a custom dialer that enforces IP validation at connection time to prevent
+// DNS rebinding (TOCTOU) attacks.
+const minimumHTTPTimeout = 1
+
+func SafePipelineHTTPClient() *http.Client {
+	timeoutSeconds := common.GetIntConfigWithDefault(common.PipelineURLTimeout, 30)
+	if timeoutSeconds < minimumHTTPTimeout {
+		timeoutSeconds = 30
+	}
+	timeout := time.Duration(timeoutSeconds) * time.Second
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.DialContext = safeDialContext
+
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return util.NewInvalidInputError("too many redirects")
+			}
+			return ValidatePipelineURL(req.URL.String())
+		},
+	}
+}
+
+// safeDialContext resolves the host, validates all IPs against blocked ranges,
+// and connects only to a validated IP. This closes the DNS TOCTOU gap where
+// a host could resolve to a safe IP during validation but a blocked IP at
+// connection time (DNS rebinding).
+func safeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid address %q: %v", addr, err)
+	}
+
+	initURLConfig()
+
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("DNS resolution failed for %q: %v", host, err)
+	}
+
+	for _, a := range addrs {
+		if isBlockedIP(a.IP) {
+			return nil, util.NewInvalidInputError("connection to blocked IP range denied")
+		}
+	}
+
+	// Connect using the resolved IPs directly
+	var dialer net.Dialer
+	for _, a := range addrs {
+		conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(a.IP.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+	}
+	return nil, fmt.Errorf("failed to connect to any resolved address for %q", host)
+}

--- a/backend/src/apiserver/validation/pipeline_url_test.go
+++ b/backend/src/apiserver/validation/pipeline_url_test.go
@@ -1,0 +1,343 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+// resetURLConfig resets the sync.Once to allow re-initialization with new config
+func resetURLConfig() {
+	urlConfigInit = sync.Once{}
+	blockedNets = nil
+	allowedDomains = nil
+}
+
+func TestValidatePipelineURL_AllowedDomains(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	// Default allowed domains should pass
+	assert.NoError(t, ValidatePipelineURL("https://storage.googleapis.com/bucket/file.yaml"))
+	assert.NoError(t, ValidatePipelineURL("https://github.com/kubeflow/pipelines/raw/main/test.yaml"))
+	assert.NoError(t, ValidatePipelineURL("https://s3.amazonaws.com/bucket/file.yaml"))
+
+	// Disallowed domain should fail
+	err := ValidatePipelineURL("https://evil.com/malicious.yaml")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not in allowlist")
+}
+
+func TestValidatePipelineURL_BlockedDomain(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	// localhost should fail (not in allowlist)
+	err := ValidatePipelineURL("https://localhost/file.yaml")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not in allowlist")
+}
+
+func TestValidatePipelineURL_SchemeRestriction(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	// HTTP blocked by default
+	err := ValidatePipelineURL("http://storage.googleapis.com/bucket/file.yaml")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "scheme")
+
+	// HTTPS allowed
+	assert.NoError(t, ValidatePipelineURL("https://storage.googleapis.com/bucket/file.yaml"))
+}
+
+func TestValidatePipelineURL_HTTPAllowedWhenConfigured(t *testing.T) {
+	viper.Reset()
+	viper.Set("PIPELINE_URL_ALLOW_HTTP", "true")
+	resetURLConfig()
+
+	// HTTP allowed when configured
+	assert.NoError(t, ValidatePipelineURL("http://storage.googleapis.com/bucket/file.yaml"))
+}
+
+func TestValidatePipelineURL_PortRestriction(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	// Default port (no port specified) should pass
+	assert.NoError(t, ValidatePipelineURL("https://storage.googleapis.com/bucket/file.yaml"))
+
+	// Explicit standard port should pass
+	assert.NoError(t, ValidatePipelineURL("https://storage.googleapis.com:443/bucket/file.yaml"))
+
+	// Non-standard port should fail
+	err := ValidatePipelineURL("https://storage.googleapis.com:8080/bucket/file.yaml")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "port")
+}
+
+func TestValidatePipelineURL_PortMustMatchScheme(t *testing.T) {
+	viper.Reset()
+	viper.Set("PIPELINE_URL_ALLOW_HTTP", "true")
+	resetURLConfig()
+
+	// HTTPS on port 80 should fail
+	err := ValidatePipelineURL("https://storage.googleapis.com:80/bucket/file.yaml")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTPS requires port 443")
+
+	// HTTP on port 443 should fail
+	err = ValidatePipelineURL("http://storage.googleapis.com:443/bucket/file.yaml")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP requires port 80")
+}
+
+func TestValidatePipelineURL_UserConfiguredDomains(t *testing.T) {
+	viper.Reset()
+	viper.Set("PIPELINE_URL_ALLOWED_DOMAINS", "example.com")
+	resetURLConfig()
+
+	// User-configured domain should pass
+	assert.NoError(t, ValidatePipelineURL("https://example.com/test.yaml"))
+
+	// Default domains should still pass
+	assert.NoError(t, ValidatePipelineURL("https://storage.googleapis.com/bucket/file.yaml"))
+}
+
+func TestValidatePipelineURL_InvalidURL(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	err := ValidatePipelineURL("not-a-valid-url")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid URL")
+}
+
+func TestValidatePipelineURL_FileSchemeBlocked(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	err := ValidatePipelineURL("file:///etc/passwd")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "scheme")
+}
+
+func TestIsBlockedIP(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+	initURLConfig()
+
+	tests := []struct {
+		ip      string
+		blocked bool
+		desc    string
+	}{
+		// Loopback
+		{"127.0.0.1", true, "IPv4 loopback"},
+		{"127.255.255.255", true, "IPv4 loopback range end"},
+		{"::1", true, "IPv6 loopback"},
+
+		// Private IPv4
+		{"10.0.0.1", true, "Private Class A"},
+		{"10.255.255.255", true, "Private Class A end"},
+		{"172.16.0.1", true, "Private Class B start"},
+		{"172.31.255.255", true, "Private Class B end"},
+		{"192.168.1.1", true, "Private Class C"},
+		{"192.168.255.255", true, "Private Class C end"},
+
+		// Link-local / metadata
+		{"169.254.0.1", true, "Link-local"},
+		{"169.254.169.254", true, "Cloud metadata endpoint"},
+
+		// Public IPs (should NOT be blocked)
+		{"8.8.8.8", false, "Google DNS"},
+		{"1.1.1.1", false, "Cloudflare DNS"},
+		{"142.250.80.46", false, "Google public"},
+		{"151.101.1.140", false, "GitHub"},
+	}
+
+	for _, tt := range tests {
+		ip := net.ParseIP(tt.ip)
+		assert.NotNil(t, ip, "Failed to parse IP: %s", tt.ip)
+		assert.Equal(t, tt.blocked, isBlockedIP(ip), "%s: IP %s should be blocked=%v", tt.desc, tt.ip, tt.blocked)
+	}
+}
+
+func TestIsBlockedIP_IPv6Metadata(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+	initURLConfig()
+
+	ip := net.ParseIP("fd00:ec2::254")
+	assert.NotNil(t, ip)
+	assert.True(t, isBlockedIP(ip), "AWS EC2 IPv6 metadata endpoint should be blocked")
+}
+
+func TestValidatePipelineURL_HostnameNormalization(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	// Trailing dot (FQDN) should be normalized and pass
+	assert.NoError(t, ValidatePipelineURL("https://storage.googleapis.com./bucket/file.yaml"))
+
+	// Mixed case should be normalized and pass
+	assert.NoError(t, ValidatePipelineURL("https://Storage.GoogleAPIs.COM/bucket/file.yaml"))
+}
+
+func TestSafePipelineHTTPClient_RedirectValidation(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	client := SafePipelineHTTPClient()
+
+	// Simulate a redirect to a disallowed domain
+	redirectRequest := &http.Request{
+		URL: &url.URL{
+			Scheme: "https",
+			Host:   "evil.com",
+			Path:   "/malicious.yaml",
+		},
+	}
+	via := []*http.Request{{}} // one prior redirect
+	err := client.CheckRedirect(redirectRequest, via)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not in allowlist")
+
+	// Simulate a redirect to an allowed domain
+	allowedRequest := &http.Request{
+		URL: &url.URL{
+			Scheme: "https",
+			Host:   "storage.googleapis.com",
+			Path:   "/bucket/redirected.yaml",
+		},
+	}
+	err = client.CheckRedirect(allowedRequest, via)
+	assert.NoError(t, err)
+}
+
+func TestSafePipelineHTTPClient_TooManyRedirects(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	client := SafePipelineHTTPClient()
+
+	redirectRequest := &http.Request{
+		URL: &url.URL{
+			Scheme: "https",
+			Host:   "storage.googleapis.com",
+			Path:   "/file.yaml",
+		},
+	}
+	// 10 prior redirects should trigger "too many redirects"
+	via := make([]*http.Request, 10)
+	err := client.CheckRedirect(redirectRequest, via)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too many redirects")
+}
+
+func TestSafePipelineHTTPClient_ZeroTimeoutDefaultsTo30(t *testing.T) {
+	viper.Reset()
+	viper.Set("PIPELINE_URL_TIMEOUT", "0")
+	resetURLConfig()
+
+	client := SafePipelineHTTPClient()
+	assert.Equal(t, 30*time.Second, client.Timeout, "Zero timeout should default to 30 seconds")
+}
+
+func TestSafePipelineHTTPClient_HasTimeout(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	client := SafePipelineHTTPClient()
+	assert.NotNil(t, client)
+	assert.True(t, client.Timeout > 0, "Client should have a timeout configured")
+}
+
+func TestSafePipelineHTTPClient_CustomTimeout(t *testing.T) {
+	viper.Reset()
+	viper.Set("PIPELINE_URL_TIMEOUT", "60")
+	resetURLConfig()
+
+	client := SafePipelineHTTPClient()
+	assert.NotNil(t, client)
+	// 60 seconds = 60,000,000,000 nanoseconds
+	assert.Equal(t, int64(60_000_000_000), int64(client.Timeout))
+}
+
+func TestSafePipelineHTTPClient_HasCustomTransport(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	client := SafePipelineHTTPClient()
+	assert.NotNil(t, client.Transport, "Client should have a custom transport to prevent DNS rebinding")
+	_, ok := client.Transport.(*http.Transport)
+	assert.True(t, ok, "Transport should be *http.Transport with custom DialContext")
+}
+
+func TestSafeDialContext_BlocksPrivateIPs(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+	initURLConfig()
+
+	ctx := context.Background()
+	// 127.0.0.1 is in the loopback blocked range
+	_, err := safeDialContext(ctx, "tcp", "127.0.0.1:443")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "blocked IP")
+}
+
+func TestSafeDialContext_BlocksMetadataIP(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+	initURLConfig()
+
+	ctx := context.Background()
+	// 169.254.169.254 is the cloud metadata endpoint
+	_, err := safeDialContext(ctx, "tcp", "169.254.169.254:80")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "blocked IP")
+}
+
+func TestSafeDialContext_InvalidAddress(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+	initURLConfig()
+
+	ctx := context.Background()
+	_, err := safeDialContext(ctx, "tcp", "no-port")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid address")
+}
+
+func TestSafePipelineHTTPClient_DisablesProxyFromEnvironment(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://squid.squid.svc.cluster.local:3128")
+	t.Setenv("HTTP_PROXY", "http://squid.squid.svc.cluster.local:3128")
+	viper.Reset()
+	resetURLConfig()
+
+	client := SafePipelineHTTPClient()
+	transport, ok := client.Transport.(*http.Transport)
+	assert.True(t, ok)
+	assert.Nil(t, transport.Proxy)
+}

--- a/frontend/src/components/PipelinesDialog.test.tsx
+++ b/frontend/src/components/PipelinesDialog.test.tsx
@@ -20,7 +20,7 @@ import PipelinesDialog, { PipelinesDialogProps } from './PipelinesDialog';
 import { PageProps } from '../pages/Page';
 import { Apis, PipelineSortKeys } from '../lib/Apis';
 import { ApiListPipelinesResponse, ApiPipeline } from '../apis/pipeline';
-import TestUtils from '../TestUtils';
+import { flushPromisesInAct } from '../TestUtils';
 import { BuildInfoContext } from '../lib/BuildInfo';
 import { NameWithTooltip } from './CustomTableNameColumn';
 
@@ -98,7 +98,7 @@ describe('PipelinesDialog', () => {
         <PipelinesDialog {...generateProps()} />
       </BuildInfoContext.Provider>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     expect(tree).toMatchSnapshot();
   });
 
@@ -108,7 +108,7 @@ describe('PipelinesDialog', () => {
         <PipelinesDialog {...generateProps()} />
       </BuildInfoContext.Provider>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/frontend/src/components/PipelinesDialogV2.test.tsx
+++ b/frontend/src/components/PipelinesDialogV2.test.tsx
@@ -20,7 +20,7 @@ import PipelinesDialogV2, { PipelinesDialogV2Props } from './PipelinesDialogV2';
 import { PageProps } from 'src/pages/Page';
 import { Apis, PipelineSortKeys } from 'src/lib/Apis';
 import { V2beta1Pipeline, V2beta1ListPipelinesResponse } from 'src/apisv2beta1/pipeline';
-import TestUtils from 'src/TestUtils';
+import { flushPromisesInAct } from 'src/TestUtils';
 import { BuildInfoContext } from 'src/lib/BuildInfo';
 import { NameWithTooltip } from 'src/components/CustomTableNameColumn';
 
@@ -95,7 +95,7 @@ describe('PipelinesDialog', () => {
         <PipelinesDialogV2 {...generateProps()} />
       </BuildInfoContext.Provider>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     expect(listPipelineSpy).toHaveBeenCalledWith('ns', '', 10, 'created_at desc', '');
     // Verify the display names are shown instead of the names
@@ -109,7 +109,7 @@ describe('PipelinesDialog', () => {
         <PipelinesDialogV2 {...generateProps()} />
       </BuildInfoContext.Provider>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     expect(listPipelineSpy).toHaveBeenCalledWith(undefined, '', 10, 'created_at desc', '');
     // Verify the display names are shown instead of the names

--- a/frontend/src/components/viewers/MetricsDropdown.test.tsx
+++ b/frontend/src/components/viewers/MetricsDropdown.test.tsx
@@ -16,7 +16,7 @@
 
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { CommonTestWrapper } from 'src/TestWrapper';
-import TestUtils, { testBestPractices } from 'src/TestUtils';
+import TestUtils, { flushPromisesInAct, testBestPractices } from 'src/TestUtils';
 import { Artifact, Event, Execution, Value } from 'src/third_party/mlmd';
 import * as metricsVisualizations from 'src/components/viewers/MetricsVisualizations';
 import * as Utils from 'src/lib/Utils';
@@ -156,7 +156,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     screen.getByText('There are no Confusion Matrix artifacts available on the selected runs.');
   });
 
@@ -169,7 +169,7 @@ describe('MetricsDropdown', () => {
         updateSelectedArtifacts={updateSelectedArtifactsSpy}
       />,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     screen.getByText('There are no HTML artifacts available on the selected runs.');
   });
 
@@ -184,7 +184,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     screen.getByText('There are no Markdown artifacts available on the selected runs.');
   });
 
@@ -199,7 +199,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     screen.getByText('Choose a first Confusion Matrix artifact');
   });
 
@@ -230,7 +230,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitFor(() => {
       expect(warnSpy).toHaveBeenLastCalledWith(
@@ -254,7 +254,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     fireEvent.click(screen.getByText('Choose a first Confusion Matrix artifact'));
     fireEvent.mouseEnter(screen.getByText('run1'));
@@ -294,7 +294,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     // Choose the first HTML element.
     fireEvent.click(screen.getByText('Choose a first HTML artifact'));
@@ -339,7 +339,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     // Choose the first Markdown element.
     fireEvent.click(screen.getByText('Choose a first Markdown artifact'));
@@ -388,7 +388,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     fireEvent.click(screen.getByText('Choose a first HTML artifact'));
     fireEvent.mouseEnter(screen.getByText('run1'));
@@ -432,7 +432,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     screen.getByText('Choose a first Confusion Matrix artifact');
     screen.getByLabelText('run1 > execution1 > artifact1');
@@ -449,7 +449,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     const nextSelectedArtifacts: SelectedArtifact[] = [
       {
@@ -518,7 +518,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     await waitFor(() => {
       expect(getHtmlViewerConfigSpy).toHaveBeenLastCalledWith([staleLinkedArtifact], undefined);
     });

--- a/frontend/src/components/viewers/MetricsVisualizations.test.tsx
+++ b/frontend/src/components/viewers/MetricsVisualizations.test.tsx
@@ -16,7 +16,7 @@
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { CommonTestWrapper } from 'src/TestWrapper';
-import { testBestPractices } from 'src/TestUtils';
+import { flushPromisesInAct, invokeAndFlush, testBestPractices } from 'src/TestUtils';
 import { Artifact, Event } from 'src/third_party/mlmd';
 import { LinkedArtifact } from 'src/mlmd/MlmdUtils';
 import { Struct, Value } from 'google-protobuf/google/protobuf/struct_pb';
@@ -27,7 +27,6 @@ import {
 } from './MetricsVisualizations';
 import { FullArtifactPath, FullArtifactPathMap, RocCurveColorMap } from 'src/lib/v2/CompareUtils';
 import { lineColors } from 'src/components/viewers/ROCCurve';
-import TestUtils from 'src/TestUtils';
 import * as rocCurveHelper from './ROCCurveHelper';
 
 testBestPractices();
@@ -209,7 +208,7 @@ describe('ConfidenceMetricsSection', () => {
         <ConfidenceMetricsSection {...generateProps([])} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     screen.getByText('ROC Curve: no artifacts');
   });
 
@@ -219,7 +218,7 @@ describe('ConfidenceMetricsSection', () => {
         <ConfidenceMetricsSection {...generateProps(['1-1'])} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     screen.getByText('ROC Curve: artifact1');
   });
 
@@ -229,7 +228,7 @@ describe('ConfidenceMetricsSection', () => {
         <ConfidenceMetricsSection {...generateProps(['1-1', '1-2'])} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     screen.getByText('ROC Curve: multiple artifacts');
   });
 
@@ -243,7 +242,7 @@ describe('ConfidenceMetricsSection', () => {
         <ConfidenceMetricsSection {...generateProps(['1-1', '1-2'])} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     expect(validateConfidenceMetricsSpy).toHaveBeenCalled();
     screen.getByText(
@@ -257,7 +256,7 @@ describe('ConfidenceMetricsSection', () => {
         <ConfidenceMetricsSection {...generateProps(['1-1', '1-2'])} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     // Only the selected items are checked.
     const selectedCheckboxes = screen
@@ -282,7 +281,7 @@ describe('ConfidenceMetricsSection', () => {
         <ConfidenceMetricsSection {...generateProps(['1-1', '1-2', '2-4'])} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     // Only the selected items are checked.
     const selectedCheckboxes = screen
@@ -314,7 +313,7 @@ describe('ConfidenceMetricsSection', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     // Only the selected items are checked.
     let checkboxes = screen.queryAllByRole('checkbox').filter((r) => r.nodeName === 'INPUT');
@@ -332,7 +331,9 @@ describe('ConfidenceMetricsSection', () => {
     const nextPage = buttons[buttons.length - 1];
 
     // Ensure none of the next page checkboxes are checked.
-    fireEvent.click(nextPage);
+    await invokeAndFlush(() => {
+      fireEvent.click(nextPage);
+    });
     checkboxes = screen.queryAllByRole('checkbox').filter((r) => r.nodeName === 'INPUT');
     selectedCheckboxes = screen
       .queryAllByRole('checkbox', { checked: true })
@@ -341,7 +342,9 @@ describe('ConfidenceMetricsSection', () => {
     expect(selectedCheckboxes).toHaveLength(0);
 
     // Selecting a disabled checkbox has no change.
-    fireEvent.click(checkboxes[1]);
+    await invokeAndFlush(() => {
+      fireEvent.click(checkboxes[1]);
+    });
     expect(setSelectedIdsSpy).toHaveBeenLastCalledWith(rocCurveData.selectedIds);
   });
 
@@ -358,7 +361,7 @@ describe('ConfidenceMetricsSection', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     const buttons = screen.queryAllByRole('button');
     const nextPage = buttons[buttons.length - 1];
@@ -380,7 +383,7 @@ describe('ConfidenceMetricsSection', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitFor(() => {
       expect(screen.getByText('execution100 > artifact100')).toBeInTheDocument();
@@ -394,7 +397,7 @@ describe('ConfidenceMetricsSection', () => {
         <ConfidenceMetricsSection {...generateProps([])} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     // Test the header columns and some different rows
     screen.getByText('Execution name > Artifact name');

--- a/frontend/src/pages/CompareV2.test.tsx
+++ b/frontend/src/pages/CompareV2.test.tsx
@@ -17,7 +17,7 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { useEffect, useState } from 'react';
 import { CommonTestWrapper } from 'src/TestWrapper';
-import TestUtils, { expectErrors, testBestPractices } from 'src/TestUtils';
+import TestUtils, { expectErrors, flushPromisesInAct, testBestPractices } from 'src/TestUtils';
 import { Artifact, Context, Event, Execution } from 'src/third_party/mlmd';
 import { Apis } from 'src/lib/Apis';
 import { ButtonKeys } from 'src/lib/Buttons';
@@ -708,7 +708,7 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     // Wait for runs to render (indicates all queries resolved) before banner clears
     await waitForRunCheckboxes(3);
@@ -761,7 +761,7 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     await waitForRunCheckboxes(3);
 
     await waitFor(
@@ -874,7 +874,7 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     screen.getByLabelText('Filter runs');
     screen.getByText('There are no Parameters available on the selected runs.');
@@ -914,7 +914,7 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitForRunCheckboxes(3);
     const headerCheckbox = getHeaderCheckbox();
@@ -935,11 +935,11 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitForRunCheckboxes(3);
     fireEvent.click(getRunRow(MOCK_RUN_2_ID));
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitForRunCheckboxes(2);
     expect(getHeaderCheckbox()).not.toBeChecked();
@@ -955,7 +955,7 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitFor(() => {
       expect(updateToolbarSpy).toHaveBeenCalled();
@@ -963,7 +963,7 @@ describe('CompareV2', () => {
     await waitForRunCheckboxes(3);
 
     fireEvent.click(getRunRow(MOCK_RUN_2_ID));
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     await waitForRunCheckboxes(2);
     expect(getRunRow(MOCK_RUN_2_ID)).toHaveAttribute('aria-checked', 'false');
 
@@ -972,7 +972,7 @@ describe('CompareV2', () => {
     await act(async () => {
       await refreshAction();
     });
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitForRunCheckboxes(2);
     expect(getRunRow(MOCK_RUN_1_ID)).toHaveAttribute('aria-checked', 'true');
@@ -1000,7 +1000,7 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitFor(() => {
       expect(updateToolbarSpy).toHaveBeenCalled();
@@ -1008,7 +1008,7 @@ describe('CompareV2', () => {
     await waitForRunCheckboxes(3);
 
     fireEvent.click(getRunRow(MOCK_RUN_2_ID));
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     await waitForRunCheckboxes(2);
 
     refreshedRunIds.add(MOCK_RUN_3_ID);
@@ -1017,7 +1017,7 @@ describe('CompareV2', () => {
     await act(async () => {
       await refreshAction();
     });
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitForRunCheckboxes(1);
     expect(getRunRow(MOCK_RUN_1_ID)).toHaveAttribute('aria-checked', 'true');
@@ -1036,11 +1036,11 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitForRunCheckboxes(3);
     fireEvent.click(getRunRow(MOCK_RUN_2_ID));
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     await waitForRunCheckboxes(2);
 
     const nextProps = generateProps();
@@ -1050,7 +1050,7 @@ describe('CompareV2', () => {
         <CompareV2 {...nextProps} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitForRunCheckboxes(2);
     expect(getRunRow(MOCK_RUN_2_ID)).toHaveAttribute('aria-checked', 'true');
@@ -1145,7 +1145,7 @@ describe('CompareV2', () => {
       </CommonTestWrapper>,
     );
 
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     await waitFor(() => {
       const lastCall = getHtmlViewerConfigSpy.mock.lastCall;
       expect(lastCall?.[0]?.[0]?.artifact.getId()).toBe(updatedArtifact.getId());

--- a/frontend/src/pages/GettingStarted.test.tsx
+++ b/frontend/src/pages/GettingStarted.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import TestUtils from 'src/TestUtils';
+import TestUtils, { flushPromisesInAct } from 'src/TestUtils';
 import { Apis } from 'src/lib/Apis';
 import { V2beta1ListPipelinesResponse } from 'src/apisv2beta1/pipeline';
 import { GettingStarted } from './GettingStarted';
@@ -63,9 +63,10 @@ describe('GettingStarted page', () => {
     pipelineListSpy.mockImplementation(() => Promise.resolve(empty));
   });
 
-  it('initially renders documentation', () => {
+  it('initially renders documentation', async () => {
     const { container } = render(<GettingStarted {...generateProps()} />);
     expect(container).toMatchSnapshot();
+    await flushPromisesInAct();
   });
 
   it('renders documentation with pipeline deep link after querying demo pipelines', async () => {
@@ -86,7 +87,7 @@ describe('GettingStarted page', () => {
       return Promise.resolve({ pipelines: [], total_size: 0 });
     });
     render(<GettingStarted {...generateProps()} />);
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     expect(pipelineListSpy.mock.calls).toMatchSnapshot();
     expect(screen.getByRole('link', { name: 'Data passing in Python components' })).toHaveAttribute(
       'href',
@@ -113,7 +114,7 @@ describe('GettingStarted page', () => {
       return Promise.resolve({ pipelines: [], total_size: 0 });
     });
     render(<GettingStarted {...generateProps()} />);
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     expect(screen.getByRole('link', { name: 'Data passing in Python components' })).toHaveAttribute(
       'href',
       '#/pipelines',

--- a/frontend/src/pages/PrivateAndSharedPipelines.test.tsx
+++ b/frontend/src/pages/PrivateAndSharedPipelines.test.tsx
@@ -19,7 +19,7 @@ import { createMemoryHistory } from 'history';
 import { PageProps } from './Page';
 import { Apis } from 'src/lib/Apis';
 import { V2beta1Pipeline, V2beta1ListPipelinesResponse } from 'src/apisv2beta1/pipeline';
-import TestUtils from 'src/TestUtils';
+import { flushPromisesInAct } from 'src/TestUtils';
 import { BuildInfoContext } from 'src/lib/BuildInfo';
 import PrivateAndSharedPipelines, {
   PrivateAndSharedProps,
@@ -93,7 +93,7 @@ describe('PrivateAndSharedPipelines', () => {
         </BuildInfoContext.Provider>
       </Router>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     expect(tree).toMatchSnapshot();
   });
 
@@ -107,7 +107,7 @@ describe('PrivateAndSharedPipelines', () => {
         </BuildInfoContext.Provider>
       </Router>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/sdk/python/kfp/cli/component.py
+++ b/sdk/python/kfp/cli/component.py
@@ -114,13 +114,16 @@ class ComponentBuilder():
             temp_dir = pathlib.Path(tempfile.mkdtemp())
             try:
                 subprocess.run([
-                    'python3',
-                    kfp_package_path / 'setup.py',
-                    'bdist_wheel',
-                    '--dist-dir',
+                    sys.executable,
+                    '-m',
+                    'pip',
+                    'wheel',
+                    '--no-deps',
+                    '--wheel-dir',
                     str(temp_dir),
+                    str(kfp_package_path),
                 ],
-                               cwd=kfp_package_path)
+                               check=True)
                 wheel_files = list(temp_dir.glob('*.whl'))
                 if len(wheel_files) != 1:
                     logging.error(

--- a/sdk/python/kfp/cli/component_test.py
+++ b/sdk/python/kfp/cli/component_test.py
@@ -607,9 +607,6 @@ class Test(unittest.TestCase):
                 COPY . .
                 '''))
 
-    @unittest.skip(
-        "Skipping this test as it's failing. Refer to https://github.com/kubeflow/pipelines/issues/11038"
-    )
     def test_dockerfile_can_contain_custom_kfp_package(self):
         component = _make_component(
             func_name='train', target_image='custom-image')


### PR DESCRIPTION
Automated sync from [kubeflow/pipelines](https://github.com/kubeflow/pipelines) `master` branch.

**Excluded files** (kept as downstream versions):
- `.tekton/*`
- `.github/renovate.json5`
- `backend/Dockerfile*`
- `**/OWNERS`

**Overwritten paths** (always taken from upstream):
- `frontend/`

---
*Created by the [Upstream Sync](https://github.com/opendatahub-io/data-science-pipelines/actions/runs/26102356308) workflow.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added enhanced security validation for pipeline URLs, including domain allowlisting, scheme restrictions, and DNS rebinding prevention.

* **Bug Fixes**
  * Improved error handling and messaging for pipeline operations.

* **Chores**
  * Updated package build process and test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->