### PR TITLE
test: adding a custom reporter to skip adding filtered out tests to the jun…

### DIFF
--- a/backend/test/end2end/e2e_suite_test.go
+++ b/backend/test/end2end/e2e_suite_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/test/logger"
 	"github.com/kubeflow/pipelines/backend/test/testutil"
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/reporters"
 	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes"
@@ -162,13 +163,32 @@ var _ = ReportAfterEach(func(specReport types.SpecReport) {
 	}
 })
 
+// Custom reporter to filter out skipped tests
+var _ = ReportAfterSuite("Generate filtered JUnit report", func(report Report) {
+	filtered := report
+	filteredSpecs := make([]types.SpecReport, 0, len(report.SpecReports))
+	for _, spec := range report.SpecReports {
+		if spec.State == types.SpecStateSkipped && spec.Failure.Message == "" || spec.LeafNodeType.Is(types.NodeTypesForSuiteLevelNodes) {
+			continue
+		}
+		filteredSpecs = append(filteredSpecs, spec)
+	}
+	filtered.SpecReports = filteredSpecs
+
+	junitPath := filepath.Join(testReportDirectory, junitReportFilename)
+	err := reporters.GenerateJUnitReportWithConfig(filtered, junitPath, reporters.JunitReportConfig{})
+	Expect(err).NotTo(HaveOccurred(), "Failed to generate filtered JUnit report")
+
+	jsonPath := filepath.Join(testReportDirectory, jsonReportFilename)
+	err = reporters.GenerateJSONReport(filtered, jsonPath)
+	Expect(err).NotTo(HaveOccurred(), "Failed to generate filtered JSON report")
+})
+
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 	suiteConfigE2E, reporterConfigE2E := GinkgoConfiguration()
 	suiteConfigE2E.FailFast = false
 	reporterConfigE2E.ForceNewlines = true
 	reporterConfigE2E.SilenceSkips = true
-	reporterConfigE2E.JUnitReport = filepath.Join(testReportDirectory, junitReportFilename)
-	reporterConfigE2E.JSONReport = filepath.Join(testReportDirectory, jsonReportFilename)
 	RunSpecs(t, "AIPipelinesE2ETests", suiteConfigE2E, reporterConfigE2E)
 }


### PR DESCRIPTION
…it and json reports

**Description of your changes:**


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [x] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reporting: a post-suite step now filters out skipped specs and generates cleaner JUnit XML and JSON reports in the existing reports directory.
  * Test setup no longer writes those artifacts directly; report generation is centralized into the post-suite reporting step for more consistent outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->