### PR TITLE
UPSTREAM<13552>: fix: allow same-named pipeline versions under different pipelines

### DIFF
--- a/backend/src/apiserver/config/config.go
+++ b/backend/src/apiserver/config/config.go
@@ -261,7 +261,8 @@ func LoadSamples(resourceManager *resource.ResourceManager, sampleConfigPath str
 		}
 
 		// Create pipeline if it does not already exist
-		p, fetchErr := resourceManager.GetPipelineByNameAndNamespace(cfg.Name, common.GetPodNamespace())
+		namespace := resourceManager.ReplaceNamespace(common.GetPodNamespace())
+		p, fetchErr := resourceManager.GetPipelineByNameAndNamespace(cfg.Name, namespace)
 		if fetchErr != nil {
 			if util.IsUserErrorCodeMatch(fetchErr, codes.NotFound) {
 				p, configErr = resourceManager.CreatePipeline(&model.Pipeline{
@@ -271,12 +272,21 @@ func LoadSamples(resourceManager *resource.ResourceManager, sampleConfigPath str
 					Tags:        tags,
 				})
 				if configErr != nil {
-					// Log the error but not fail. The API Server pod can restart and it could potentially cause
-					// name collision. In the future, we might consider loading samples during deployment, instead
-					// of when API server starts.
-					glog.Warningf(fmt.Sprintf(
-						"Failed to create pipeline for %s. Error: %v", cfg.Name, configErr))
-					continue
+					if util.IsUserErrorCodeMatch(configErr, codes.AlreadyExists) {
+						// Retry without namespace filter. In standalone mode this
+						// finds the empty-namespace pipeline; safe because sample
+						// names are deterministic and collisions across namespaces
+						// are not expected for managed pipelines.
+						p, fetchErr = resourceManager.GetPipelineByNameAndNamespace(cfg.Name, "")
+						if fetchErr != nil {
+							glog.Warningf("Failed to create or find pipeline %s: create=%v, fetch=%v", cfg.Name, configErr, fetchErr)
+							continue
+						}
+						glog.Infof("Pipeline %s already exists (id=%s), proceeding to version check.", cfg.Name, p.UUID)
+					} else {
+						glog.Warningf("Failed to create pipeline for %s. Error: %v", cfg.Name, configErr)
+						continue
+					}
 				} else {
 					glog.Info(fmt.Sprintf("Successfully uploaded Pipeline %s.", cfg.Name))
 				}
@@ -311,7 +321,7 @@ func LoadSamples(resourceManager *resource.ResourceManager, sampleConfigPath str
 		// If the Pipeline Version exists, do nothing
 		// Otherwise upload new Pipeline Version for
 		// this pipeline.
-		_, fetchErr = resourceManager.GetPipelineVersionByName(pvName)
+		_, fetchErr = resourceManager.GetPipelineVersionByName(p.UUID, pvName)
 		if fetchErr != nil {
 			if util.IsUserErrorCodeMatch(fetchErr, codes.NotFound) {
 				_, configErr = resourceManager.CreatePipelineVersion(

--- a/backend/src/apiserver/config/config_test.go
+++ b/backend/src/apiserver/config/config_test.go
@@ -324,7 +324,7 @@ func TestLoadSamples_SameVersionNameDifferentPipelines(t *testing.T) {
 
 	path, err := writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 
 	pipelineA, err := rm.GetPipelineByNameAndNamespace("Pipeline A", "")
 	require.NoError(t, err)
@@ -552,7 +552,7 @@ func TestLoadSamples_MultiUserMode_PipelinesVisibleWithoutNamespace(t *testing.T
 
 	path, err := writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 
 	// A client querying without a namespace (empty namespace) must still
 	// find the sample pipelines. This matches the artifact proxy test
@@ -597,7 +597,7 @@ func TestLoadSamples_MultiUserMode_RestartIdempotency(t *testing.T) {
 
 	path, err := writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 
 	pipeline, err := rm.GetPipelineByNameAndNamespace("Sample Pipeline", "")
 	require.NoError(t, err)
@@ -607,7 +607,7 @@ func TestLoadSamples_MultiUserMode_RestartIdempotency(t *testing.T) {
 	// triggering the AlreadyExists fallback.
 	path, err = writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 
 	opts, err := list.NewOptions(&model.PipelineVersion{}, 10, "id", nil)
 	require.NoError(t, err)
@@ -639,7 +639,7 @@ func TestLoadSamples_MultiUserMode_RestartNewVersion(t *testing.T) {
 
 	path, err := writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 
 	pipeline, err := rm.GetPipelineByNameAndNamespace("Sample Pipeline", "")
 	require.NoError(t, err)
@@ -648,7 +648,7 @@ func TestLoadSamples_MultiUserMode_RestartNewVersion(t *testing.T) {
 	pc.Pipelines[0].VersionName = "v2"
 	path, err = writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 
 	opts, err := list.NewOptions(&model.PipelineVersion{}, 10, "id", nil)
 	require.NoError(t, err)
@@ -709,7 +709,7 @@ func TestLoadSamples_PreExistingPipelineNamespaceSwitch(t *testing.T) {
 	}
 	path, err := writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 
 	pipeline, err := rm.GetPipelineByNameAndNamespace("My Pipeline", "")
 	require.NoError(t, err)
@@ -720,7 +720,7 @@ func TestLoadSamples_PreExistingPipelineNamespaceSwitch(t *testing.T) {
 	pc.Pipelines[0].VersionName = "v2"
 	path, err = writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 
 	// Step 3: Assert: the new version was created under the existing pipeline
 	opts, err := list.NewOptions(&model.PipelineVersion{}, 10, "id", nil)
@@ -748,7 +748,7 @@ func TestLoadSamples_IdempotencyAcrossNamespaceSwitch(t *testing.T) {
 	}
 	path, err := writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 
 	pipeline, err := rm.GetPipelineByNameAndNamespace("My Pipeline", "")
 	require.NoError(t, err)
@@ -758,7 +758,7 @@ func TestLoadSamples_IdempotencyAcrossNamespaceSwitch(t *testing.T) {
 	viper.Set("POD_NAMESPACE", "test-namespace")
 	path, err = writeSampleConfig(t, pc, "sample.json")
 	require.NoError(t, err)
-	require.NoError(t, LoadSamples(rm, path))
+	require.NoError(t, LoadSamples(rm, path, ""))
 
 	// Step 3: Assert: no duplicate version was created
 	opts, err := list.NewOptions(&model.PipelineVersion{}, 10, "id", nil)
@@ -935,18 +935,18 @@ func TestLoadSamples_MergesManagedManifest(t *testing.T) {
 
 	require.NoError(t, LoadSamples(rm, samplePath, managedDir))
 
-	_, err = rm.GetPipelineByNameAndNamespace("Explicit Pipeline", "")
+	explicitPipeline, err := rm.GetPipelineByNameAndNamespace("Explicit Pipeline", "")
 	require.NoError(t, err)
-	_, err = rm.GetPipelineByNameAndNamespace("managed-a", "")
+	managedA, err := rm.GetPipelineByNameAndNamespace("managed-a", "")
 	require.NoError(t, err)
-	_, err = rm.GetPipelineByNameAndNamespace("managed-b", "")
+	managedB, err := rm.GetPipelineByNameAndNamespace("managed-b", "")
 	require.NoError(t, err)
 
-	_, err = rm.GetPipelineVersionByName("Explicit Pipeline - Ver 1")
+	_, err = rm.GetPipelineVersionByName(explicitPipeline.UUID, "Explicit Pipeline - Ver 1")
 	require.NoError(t, err)
-	_, err = rm.GetPipelineVersionByName("managed-a")
+	_, err = rm.GetPipelineVersionByName(managedA.UUID, "managed-a")
 	require.NoError(t, err)
-	_, err = rm.GetPipelineVersionByName("managed-b")
+	_, err = rm.GetPipelineVersionByName(managedB.UUID, "managed-b")
 	require.NoError(t, err)
 }
 

--- a/backend/src/apiserver/config/config_test.go
+++ b/backend/src/apiserver/config/config_test.go
@@ -57,14 +57,16 @@ func TestLoadSamplesConfigBackwardsCompatibility(t *testing.T) {
 	err = LoadSamples(rm, path, "")
 	require.NoError(t, err)
 
-	_, err = rm.GetPipelineByNameAndNamespace(pc[0].Name, "")
+	p1, err := rm.GetPipelineByNameAndNamespace(pc[0].Name, "")
 	require.NoError(t, err)
-	_, err = rm.GetPipelineByNameAndNamespace(pc[1].Name, "")
+	require.NotNil(t, p1)
+	p2, err := rm.GetPipelineByNameAndNamespace(pc[1].Name, "")
 	require.NoError(t, err)
+	require.NotNil(t, p2)
 
-	_, err = rm.GetPipelineVersionByName(pc[0].Name)
+	_, err = rm.GetPipelineVersionByName(p1.UUID, pc[0].Name)
 	require.NoError(t, err)
-	_, err = rm.GetPipelineVersionByName(pc[1].Name)
+	_, err = rm.GetPipelineVersionByName(p2.UUID, pc[1].Name)
 	require.NoError(t, err)
 
 	// Update pipeline version for Pipeline 1
@@ -148,7 +150,8 @@ func TestLoadSamples(t *testing.T) {
 	var pipeline1 *model.Pipeline
 	pipeline1, err = rm.GetPipelineByNameAndNamespace(pc.Pipelines[0].Name, "")
 	require.NoError(t, err)
-	version1, err := rm.GetPipelineVersionByName(pc.Pipelines[0].VersionName)
+	require.NotNil(t, pipeline1)
+	version1, err := rm.GetPipelineVersionByName(pipeline1.UUID, pc.Pipelines[0].VersionName)
 	require.NoError(t, err)
 	// Verify that the pipeline display name is set to the pipeline name if not provided
 	assert.Equal(t, pipeline1.DisplayName, pc.Pipelines[0].Name)
@@ -156,7 +159,8 @@ func TestLoadSamples(t *testing.T) {
 	var pipeline2 *model.Pipeline
 	pipeline2, err = rm.GetPipelineByNameAndNamespace(pc.Pipelines[1].Name, "")
 	require.NoError(t, err)
-	version2, err := rm.GetPipelineVersionByName(pc.Pipelines[1].VersionName)
+	require.NotNil(t, pipeline2)
+	version2, err := rm.GetPipelineVersionByName(pipeline2.UUID, pc.Pipelines[1].VersionName)
 	// Verify that the pipeline display name is set to the pipeline name if not provided
 	assert.Equal(t, pipeline2.DisplayName, pc.Pipelines[1].Name)
 	assert.Equal(t, version2.DisplayName, pc.Pipelines[1].VersionName)
@@ -165,36 +169,40 @@ func TestLoadSamples(t *testing.T) {
 	// Test display name for Pipeline 3 (pipeline display name only)
 	pipeline3, err := rm.GetPipelineByNameAndNamespace(pc.Pipelines[2].Name, "")
 	require.NoError(t, err)
+	require.NotNil(t, pipeline3)
 	assert.Equal(t, pc.Pipelines[2].DisplayName, pipeline3.DisplayName)
-	version3, err := rm.GetPipelineVersionByName(pc.Pipelines[2].VersionName)
+	version3, err := rm.GetPipelineVersionByName(pipeline3.UUID, pc.Pipelines[2].VersionName)
 	require.NoError(t, err)
 	assert.Equal(t, pc.Pipelines[2].VersionName, version3.DisplayName) // Should use version name when no version display name is provided
 
 	// Test display name for Pipeline 4 (version display name only)
 	pipeline4, err := rm.GetPipelineByNameAndNamespace(pc.Pipelines[3].Name, "")
 	require.NoError(t, err)
+	require.NotNil(t, pipeline4)
 	assert.Equal(t, pc.Pipelines[3].Name, pipeline4.DisplayName) // Should use pipeline name
-	version4, err := rm.GetPipelineVersionByName(pc.Pipelines[3].VersionName)
+	version4, err := rm.GetPipelineVersionByName(pipeline4.UUID, pc.Pipelines[3].VersionName)
 	require.NoError(t, err)
 	assert.Equal(t, pc.Pipelines[3].VersionDisplayName, version4.DisplayName)
 
 	// Test display name for Pipeline 5 (both display names)
 	pipeline5, err := rm.GetPipelineByNameAndNamespace(pc.Pipelines[4].Name, "")
 	require.NoError(t, err)
+	require.NotNil(t, pipeline5)
 	assert.Equal(t, pc.Pipelines[4].DisplayName, pipeline5.DisplayName)
-	version5, err := rm.GetPipelineVersionByName(pc.Pipelines[4].VersionName)
+	version5, err := rm.GetPipelineVersionByName(pipeline5.UUID, pc.Pipelines[4].VersionName)
 	require.NoError(t, err)
 	assert.Equal(t, pc.Pipelines[4].VersionDisplayName, version5.DisplayName)
 
 	// Test display name for Pipeline 6 (only pipeline name)
 	pipeline6, err := rm.GetPipelineByNameAndNamespace(pc.Pipelines[5].Name, "")
 	require.NoError(t, err)
-	assert.Equal(t, pc.Pipelines[5].Name, pipeline6.DisplayName)       // Should use pipeline name
-	version6, err := rm.GetPipelineVersionByName(pc.Pipelines[5].Name) // Version name should default to pipeline name
+	require.NotNil(t, pipeline6)
+	assert.Equal(t, pc.Pipelines[5].Name, pipeline6.DisplayName)                       // Should use pipeline name
+	version6, err := rm.GetPipelineVersionByName(pipeline6.UUID, pc.Pipelines[5].Name) // Version name should default to pipeline name
 	require.NoError(t, err)
 	assert.Equal(t, pc.Pipelines[5].Name, version6.DisplayName) // Version display name should default to pipeline name
 
-	_, err = rm.GetPipelineVersionByName(pc.Pipelines[0].VersionName)
+	_, err = rm.GetPipelineVersionByName(pipeline1.UUID, pc.Pipelines[0].VersionName)
 	require.NoError(t, err)
 
 	// Update pipeline version for Pipeline 1
@@ -219,7 +227,7 @@ func TestLoadSamples(t *testing.T) {
 	require.NoError(t, err)
 
 	// Expect another Pipeline version added for Pipeline 2
-	_, err = rm.GetPipelineVersionByName(pc.Pipelines[1].VersionName)
+	_, err = rm.GetPipelineVersionByName(pipeline2.UUID, pc.Pipelines[1].VersionName)
 	require.NoError(t, err)
 	_, totalSize, _, err = rm.ListPipelineVersions(pipeline2.UUID, opts, nil)
 	require.NoError(t, err)
@@ -278,10 +286,11 @@ func TestLoadSamplesMultiplePipelineVersionsInConfig(t *testing.T) {
 	var pipeline *model.Pipeline
 	pipeline, err = rm.GetPipelineByNameAndNamespace(pc.Pipelines[0].Name, "")
 	require.NoError(t, err)
+	require.NotNil(t, pipeline)
 
-	_, err = rm.GetPipelineVersionByName(pc.Pipelines[0].VersionName)
+	_, err = rm.GetPipelineVersionByName(pipeline.UUID, pc.Pipelines[0].VersionName)
 	require.NoError(t, err)
-	_, err = rm.GetPipelineVersionByName(pc.Pipelines[1].VersionName)
+	_, err = rm.GetPipelineVersionByName(pipeline.UUID, pc.Pipelines[1].VersionName)
 	require.NoError(t, err)
 
 	opts, err := list.NewOptions(&model.PipelineVersion{}, 10, "id", nil)
@@ -290,6 +299,50 @@ func TestLoadSamplesMultiplePipelineVersionsInConfig(t *testing.T) {
 	_, totalSize, _, err := rm.ListPipelineVersions(pipeline.UUID, opts, nil)
 	require.NoError(t, err)
 	require.Equal(t, totalSize, 2)
+}
+
+func TestLoadSamples_SameVersionNameDifferentPipelines(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	rm := fakeResourceManager()
+	pc := config{
+		LoadSamplesOnRestart: true,
+		Pipelines: []configPipelines{
+			{
+				Name:        "Pipeline A",
+				Description: "test description",
+				File:        "testdata/sample_pipeline.yaml",
+				VersionName: "v1.0",
+			},
+			{
+				Name:        "Pipeline B",
+				Description: "test description",
+				File:        "testdata/sample_pipeline.yaml",
+				VersionName: "v1.0",
+			},
+		},
+	}
+
+	path, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, path))
+
+	pipelineA, err := rm.GetPipelineByNameAndNamespace("Pipeline A", "")
+	require.NoError(t, err)
+	require.NotNil(t, pipelineA)
+
+	pipelineB, err := rm.GetPipelineByNameAndNamespace("Pipeline B", "")
+	require.NoError(t, err)
+	require.NotNil(t, pipelineB)
+
+	versionA, err := rm.GetPipelineVersionByName(pipelineA.UUID, "v1.0")
+	require.NoError(t, err)
+	assert.Equal(t, pipelineA.UUID, versionA.PipelineId)
+
+	versionB, err := rm.GetPipelineVersionByName(pipelineB.UUID, "v1.0")
+	require.NoError(t, err)
+	assert.Equal(t, pipelineB.UUID, versionB.PipelineId)
+
+	assert.NotEqual(t, versionA.UUID, versionB.UUID)
 }
 
 func TestParseManagedPipelinesTags(t *testing.T) {
@@ -383,9 +436,10 @@ func TestLoadSamples_TagsApplied(t *testing.T) {
 
 	pipeline, err := rm.GetPipelineByNameAndNamespace("Tagged Pipeline", "")
 	require.NoError(t, err)
+	require.NotNil(t, pipeline)
 	assert.Equal(t, wantTags, pipeline.Tags)
 
-	version, err := rm.GetPipelineVersionByName("Tagged Pipeline - Ver 1")
+	version, err := rm.GetPipelineVersionByName(pipeline.UUID, "Tagged Pipeline - Ver 1")
 	require.NoError(t, err)
 	assert.Empty(t, version.Tags)
 }
@@ -413,9 +467,10 @@ func TestLoadSamples_NoTagsWhenEnvUnset(t *testing.T) {
 
 	pipeline, err := rm.GetPipelineByNameAndNamespace("Untagged Pipeline", "")
 	require.NoError(t, err)
+	require.NotNil(t, pipeline)
 	assert.Empty(t, pipeline.Tags)
 
-	version, err := rm.GetPipelineVersionByName("Untagged Pipeline - Ver 1")
+	version, err := rm.GetPipelineVersionByName(pipeline.UUID, "Untagged Pipeline - Ver 1")
 	require.NoError(t, err)
 	assert.Empty(t, version.Tags)
 }
@@ -474,6 +529,134 @@ func TestLoadSamples_MalformedTagsIgnoredWhenLoadingSkipped(t *testing.T) {
 	require.NoError(t, LoadSamples(rm, path, ""))
 }
 
+func TestLoadSamples_MultiUserMode_PipelinesVisibleWithoutNamespace(t *testing.T) {
+	viper.Set("MULTIUSER", "true")
+	viper.Set("POD_NAMESPACE", "kubeflow")
+	defer func() {
+		viper.Set("MULTIUSER", "false")
+		viper.Set("POD_NAMESPACE", "")
+	}()
+
+	rm := fakeResourceManager()
+	pc := config{
+		LoadSamplesOnRestart: true,
+		Pipelines: []configPipelines{
+			{
+				Name:        "Sample Pipeline",
+				Description: "multi-user sample",
+				File:        "testdata/sample_pipeline.yaml",
+				VersionName: "Sample Pipeline - Ver 1",
+			},
+		},
+	}
+
+	path, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, path))
+
+	// A client querying without a namespace (empty namespace) must still
+	// find the sample pipelines. This matches the artifact proxy test
+	// path: GET /apis/v2beta1/pipelines?page_size=1 with no namespace.
+	pipeline, err := rm.GetPipelineByNameAndNamespace("Sample Pipeline", "")
+	require.NoError(t, err, "sample pipeline must be findable with empty namespace")
+	require.NotNil(t, pipeline)
+
+	// Also verify via ListPipelines with an empty-namespace filter context,
+	// which is how the v2beta1 API handler builds the query.
+	filterContext := &model.FilterContext{
+		ReferenceKey: &model.ReferenceKey{Type: model.NamespaceResourceType, ID: ""},
+	}
+	opts, err := list.NewOptions(&model.Pipeline{}, 10, "", nil)
+	require.NoError(t, err)
+	pipelines, totalSize, _, err := rm.ListPipelines(filterContext, opts, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, totalSize, "should find exactly 1 sample pipeline with empty namespace filter")
+	assert.Len(t, pipelines, 1)
+}
+
+func TestLoadSamples_MultiUserMode_RestartIdempotency(t *testing.T) {
+	viper.Set("MULTIUSER", "true")
+	viper.Set("POD_NAMESPACE", "kubeflow")
+	defer func() {
+		viper.Set("MULTIUSER", "false")
+		viper.Set("POD_NAMESPACE", "")
+	}()
+
+	rm := fakeResourceManager()
+	pc := config{
+		LoadSamplesOnRestart: true,
+		Pipelines: []configPipelines{
+			{
+				Name:        "Sample Pipeline",
+				Description: "multi-user sample",
+				File:        "testdata/sample_pipeline.yaml",
+				VersionName: "v1",
+			},
+		},
+	}
+
+	path, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, path))
+
+	pipeline, err := rm.GetPipelineByNameAndNamespace("Sample Pipeline", "")
+	require.NoError(t, err)
+
+	// Second load (simulates API server restart). The lookup uses
+	// namespace="kubeflow" which won't find the empty-namespace pipeline,
+	// triggering the AlreadyExists fallback.
+	path, err = writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, path))
+
+	opts, err := list.NewOptions(&model.PipelineVersion{}, 10, "id", nil)
+	require.NoError(t, err)
+	_, totalSize, _, err := rm.ListPipelineVersions(pipeline.UUID, opts, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, totalSize, "restart must not duplicate pipeline version")
+}
+
+func TestLoadSamples_MultiUserMode_RestartNewVersion(t *testing.T) {
+	viper.Set("MULTIUSER", "true")
+	viper.Set("POD_NAMESPACE", "kubeflow")
+	defer func() {
+		viper.Set("MULTIUSER", "false")
+		viper.Set("POD_NAMESPACE", "")
+	}()
+
+	rm := fakeResourceManager()
+	pc := config{
+		LoadSamplesOnRestart: true,
+		Pipelines: []configPipelines{
+			{
+				Name:        "Sample Pipeline",
+				Description: "multi-user sample",
+				File:        "testdata/sample_pipeline.yaml",
+				VersionName: "v1",
+			},
+		},
+	}
+
+	path, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, path))
+
+	pipeline, err := rm.GetPipelineByNameAndNamespace("Sample Pipeline", "")
+	require.NoError(t, err)
+
+	// Second load with a new version name (simulates config update + restart).
+	pc.Pipelines[0].VersionName = "v2"
+	path, err = writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, path))
+
+	opts, err := list.NewOptions(&model.PipelineVersion{}, 10, "id", nil)
+	require.NoError(t, err)
+	_, totalSize, _, err := rm.ListPipelineVersions(pipeline.UUID, opts, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, totalSize, "new version should be created under existing pipeline")
+}
+
 func TestLoadSamples_ExistingPipelineNotRetagged(t *testing.T) {
 	viper.Set("POD_NAMESPACE", "")
 	rm := fakeResourceManager()
@@ -506,6 +689,83 @@ func TestLoadSamples_ExistingPipelineNotRetagged(t *testing.T) {
 	pipeline, err := rm.GetPipelineByNameAndNamespace("Existing Pipeline", "")
 	require.NoError(t, err)
 	assert.Empty(t, pipeline.Tags)
+}
+
+func TestLoadSamples_PreExistingPipelineNamespaceSwitch(t *testing.T) {
+	rm := fakeResourceManager()
+
+	// Step 1: Load with empty namespace — pipeline stored with Namespace = ""
+	viper.Set("POD_NAMESPACE", "")
+	pc := config{
+		LoadSamplesOnRestart: true,
+		Pipelines: []configPipelines{
+			{
+				Name:        "My Pipeline",
+				Description: "test description",
+				File:        "testdata/sample_pipeline.yaml",
+				VersionName: "v1",
+			},
+		},
+	}
+	path, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, path))
+
+	pipeline, err := rm.GetPipelineByNameAndNamespace("My Pipeline", "")
+	require.NoError(t, err)
+	require.NotNil(t, pipeline)
+
+	// Step 2: Switch to non-empty namespace and add a new version
+	viper.Set("POD_NAMESPACE", "test-namespace")
+	pc.Pipelines[0].VersionName = "v2"
+	path, err = writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, path))
+
+	// Step 3: Assert: the new version was created under the existing pipeline
+	opts, err := list.NewOptions(&model.PipelineVersion{}, 10, "id", nil)
+	require.NoError(t, err)
+	_, totalSize, _, err := rm.ListPipelineVersions(pipeline.UUID, opts, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, totalSize)
+}
+
+func TestLoadSamples_IdempotencyAcrossNamespaceSwitch(t *testing.T) {
+	rm := fakeResourceManager()
+
+	// Step 1: Load with empty namespace
+	viper.Set("POD_NAMESPACE", "")
+	pc := config{
+		LoadSamplesOnRestart: true,
+		Pipelines: []configPipelines{
+			{
+				Name:        "My Pipeline",
+				Description: "test description",
+				File:        "testdata/sample_pipeline.yaml",
+				VersionName: "v1",
+			},
+		},
+	}
+	path, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, path))
+
+	pipeline, err := rm.GetPipelineByNameAndNamespace("My Pipeline", "")
+	require.NoError(t, err)
+	require.NotNil(t, pipeline)
+
+	// Step 2: Switch namespace but keep same version name
+	viper.Set("POD_NAMESPACE", "test-namespace")
+	path, err = writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, path))
+
+	// Step 3: Assert: no duplicate version was created
+	opts, err := list.NewOptions(&model.PipelineVersion{}, 10, "id", nil)
+	require.NoError(t, err)
+	_, totalSize, _, err := rm.ListPipelineVersions(pipeline.UUID, opts, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, totalSize)
 }
 
 func writeSampleConfig(t *testing.T, config config, path string) (string, error) {

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -2048,11 +2048,11 @@ func (r *ResourceManager) GetPipelineVersion(pipelineVersionId string) (*model.P
 	return pipelineVersion, nil
 }
 
-// GetPipelineVersionByName returns a pipeline version by Name. Tags are loaded at the store level.
-func (r *ResourceManager) GetPipelineVersionByName(name string) (*model.PipelineVersion, error) {
-	pipelineVersion, err := r.pipelineStore.GetPipelineVersionByName(name)
+// GetPipelineVersionByName returns a pipeline version by pipeline ID and version name. Tags are loaded at the store level.
+func (r *ResourceManager) GetPipelineVersionByName(pipelineID, versionName string) (*model.PipelineVersion, error) {
+	pipelineVersion, err := r.pipelineStore.GetPipelineVersionByName(pipelineID, versionName)
 	if err != nil {
-		return nil, util.Wrapf(err, "Failed to get a pipeline version with name %v", name)
+		return nil, util.Wrapf(err, "Failed to get a pipeline version with pipelineID=%v and name=%v", pipelineID, versionName)
 	}
 	return pipelineVersion, nil
 }

--- a/backend/src/apiserver/storage/pipeline_store.go
+++ b/backend/src/apiserver/storage/pipeline_store.go
@@ -105,7 +105,7 @@ type PipelineStoreInterface interface {
 	CreatePipelineVersion(pipelineVersion *model.PipelineVersion) (*model.PipelineVersion, error)
 	GetPipelineVersionWithStatus(pipelineVersionId string, status model.PipelineVersionStatus) (*model.PipelineVersion, error)
 	GetPipelineVersion(pipelineVersionId string) (*model.PipelineVersion, error)
-	GetPipelineVersionByName(name string) (*model.PipelineVersion, error)
+	GetPipelineVersionByName(pipelineID, versionName string) (*model.PipelineVersion, error)
 	GetLatestPipelineVersion(pipelineId string) (*model.PipelineVersion, error)
 	ListPipelineVersions(pipelineID string, opts *list.Options, tagFilters map[string]string) ([]*model.PipelineVersion, int, string, error)
 	UpdatePipelineVersionStatus(pipelineVersionId string, status model.PipelineVersionStatus) error
@@ -1055,11 +1055,35 @@ func (s *PipelineStore) GetPipelineVersion(versionId string) (*model.PipelineVer
 	return version, nil
 }
 
-func (s *PipelineStore) GetPipelineVersionByName(name string) (*model.PipelineVersion, error) {
-	version, err := s.getPipelineVersionByCol("Name", name, model.PipelineVersionReady)
+func (s *PipelineStore) GetPipelineVersionByName(pipelineID, versionName string) (*model.PipelineVersion, error) {
+	query, args, err := sq.
+		Select(pipelineVersionColumns...).
+		From("pipeline_versions").
+		Where(sq.And{
+			sq.Eq{"pipeline_versions.Name": versionName},
+			sq.Eq{"pipeline_versions.PipelineId": pipelineID},
+			sq.Eq{"pipeline_versions.Status": model.PipelineVersionReady},
+		}).
+		ToSql()
 	if err != nil {
-		return nil, err
+		return nil, util.NewInternalServerError(err, "Failed to create query to fetch pipeline version with name=%v and pipelineId=%v", versionName, pipelineID)
 	}
+
+	r, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, util.NewInternalServerError(err, "Failed fetching pipeline version with name=%v and pipelineId=%v", versionName, pipelineID)
+	}
+	defer r.Close()
+
+	versions, err := s.scanPipelineVersionsRows(r)
+	if err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to parse pipeline version with name=%v and pipelineId=%v", versionName, pipelineID)
+	}
+	if len(versions) == 0 {
+		return nil, util.NewResourceNotFoundError("PipelineVersion", versionName)
+	}
+
+	version := versions[0]
 	tags, err := s.GetPipelineVersionTags(version.UUID)
 	if err != nil {
 		return nil, util.NewInternalServerError(err, "Failed to load tags for pipeline version %v", version.UUID)

--- a/backend/src/apiserver/storage/pipeline_store_kubernetes.go
+++ b/backend/src/apiserver/storage/pipeline_store_kubernetes.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -205,12 +206,10 @@ func (k *PipelineStoreKubernetes) CreatePipelineAndPipelineVersion(pipeline *mod
 	pipeline.UUID = ""
 	pipelineVersion.UUID = ""
 
-	// Validate the pipeline version name before creating either resource to ensure atomicity.
-	if errs := validation.IsDNS1123Subdomain(pipelineVersion.Name); len(errs) > 0 {
-		return nil, nil, util.NewInvalidInputError(
-			"Invalid pipeline version name %q: %s. Use 'display_name' for human-readable labels",
-			pipelineVersion.Name, strings.Join(errs, "; "),
-		)
+	if pipeline.Name != pipelineVersion.Name {
+		if _, err := v2beta1.NewPipelineVersionName(pipeline.Name, pipelineVersion.Name); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	var err error
@@ -367,22 +366,55 @@ func (k *PipelineStoreKubernetes) GetPipelineVersion(pipelineVersionId string) (
 	return pipelineVersion.ToModel()
 }
 
-func (k *PipelineStoreKubernetes) GetPipelineVersionByName(name string) (*model.PipelineVersion, error) {
-	pipelineVersion := v2beta1.PipelineVersion{}
-
-	if common.GetPodNamespace() == "" {
-		return nil, fmt.Errorf("Error returning the pod namespace. Ensure you have POD_NAMESPACE environment variable set in the API Server pod.")
+// GetPipelineVersionByName returns a pipeline version by name under the given pipeline.
+// It resolves the pipeline's namespace and name via getK8sPipeline, then performs a
+// two-stage lookup: first by composite name ({pipelineName}-{versionName}), then by
+// bare name (CRs created before composite naming, or managed via GitOps). Both stages
+// verify ownership via OwnerReferences before returning.
+func (k *PipelineStoreKubernetes) GetPipelineVersionByName(pipelineID, versionName string) (*model.PipelineVersion, error) {
+	k8sPipeline, err := k.getK8sPipeline(pipelineID)
+	if err != nil {
+		return nil, err
 	}
 
+	return k.getPipelineVersionByNameInNamespace(k8sPipeline.Namespace, pipelineID, k8sPipeline.Name, versionName)
+}
+
+func (k *PipelineStoreKubernetes) getPipelineVersionByNameInNamespace(namespace, pipelineID, pipelineName, versionName string) (*model.PipelineVersion, error) {
+	pipelineVersion := v2beta1.PipelineVersion{}
+
+	// Try composite name first ({pipelineName}-{versionName})
+	if pipelineName != "" {
+		compositeName := pipelineName + "-" + versionName
+		err := k.client.Get(context.TODO(), ctrlclient.ObjectKey{
+			Namespace: namespace,
+			Name:      compositeName,
+		}, &pipelineVersion)
+		if err == nil {
+			if pipelineVersion.IsOwnedByPipeline(pipelineID) {
+				return pipelineVersion.ToModel()
+			}
+			// Composite name exists but belongs to a different pipeline (hyphen
+			// collision). Fall through to bare-name lookup.
+		} else if !k8serrors.IsNotFound(err) {
+			return nil, err
+		}
+	}
+
+	// Fallback: try bare name (CRs created before composite naming, or managed via GitOps)
 	err := k.client.Get(context.TODO(), ctrlclient.ObjectKey{
-		Namespace: common.GetPodNamespace(),
-		Name:      name,
+		Namespace: namespace,
+		Name:      versionName,
 	}, &pipelineVersion)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, util.NewResourceNotFoundError("PipelineVersion", name)
+			return nil, util.NewResourceNotFoundError("PipelineVersion", versionName)
 		}
 		return nil, err
+	}
+
+	if !pipelineVersion.IsOwnedByPipeline(pipelineID) {
+		return nil, util.NewResourceNotFoundError("PipelineVersion", versionName)
 	}
 
 	return pipelineVersion.ToModel()
@@ -665,17 +697,23 @@ func (k *PipelineStoreKubernetes) getK8sPipelineVersion(ctx context.Context, pip
 }
 
 func (k *PipelineStoreKubernetes) createPipelineVersionWithPipeline(ctx context.Context, pipeline *model.Pipeline, pipelineVersion *model.PipelineVersion) (*model.PipelineVersion, error) {
-	// Validate the pipeline version name is a valid Kubernetes resource name before sending to the API.
-	if errs := validation.IsDNS1123Subdomain(pipelineVersion.Name); len(errs) > 0 {
-		return nil, util.NewInvalidInputError(
-			"Invalid pipeline version name %q: %s. Use 'display_name' for human-readable labels",
-			pipelineVersion.Name, strings.Join(errs, "; "),
-		)
-	}
-
 	k8sPipelineVersion, err := v2beta1.FromPipelineVersionModel(*pipeline, *pipelineVersion)
 	if err != nil {
+		var userError *util.UserError
+		if errors.As(err, &userError) {
+			return nil, err
+		}
 		return nil, util.NewBadRequestError(err, "Invalid pipeline spec")
+	}
+
+	// Check for logical name collision (covers legacy bare-name CRs and composite-name CRs)
+	if _, lookupErr := k.getPipelineVersionByNameInNamespace(pipeline.Namespace, pipeline.UUID, pipeline.Name, pipelineVersion.Name); lookupErr == nil {
+		return nil, util.NewAlreadyExistError(
+			"Failed to create a new pipeline version. The name %v already exists. Please specify a new name",
+			pipelineVersion.Name,
+		)
+	} else if !util.IsUserErrorCodeMatch(lookupErr, codes.NotFound) {
+		return nil, lookupErr
 	}
 
 	glog.Infof(
@@ -684,8 +722,8 @@ func (k *PipelineStoreKubernetes) createPipelineVersionWithPipeline(ctx context.
 	err = k.client.Create(ctx, k8sPipelineVersion)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, util.NewAlreadyExistError(
-			"Failed to create a new pipeline version. The name %v already exists. Please specify a new name",
-			pipelineVersion.Name,
+			"Failed to create a new pipeline version. The name %v already exists (resource name: %v). Please specify a new name",
+			pipelineVersion.Name, k8sPipelineVersion.Name,
 		)
 	} else if k8serrors.IsInvalid(err) && strings.Contains(err.Error(), "metadata.name") {
 		return nil, util.NewBadKubernetesNameError("pipeline version")

--- a/backend/src/apiserver/storage/pipeline_store_kubernetes_compat_test.go
+++ b/backend/src/apiserver/storage/pipeline_store_kubernetes_compat_test.go
@@ -1,0 +1,710 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/glog"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/list"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/kubeflow/pipelines/backend/src/crd/kubernetes/v2beta1"
+)
+
+func TestBackwardCompat_GetPipelineVersion_LegacyCR(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	store := NewPipelineStoreKubernetes(getClient())
+
+	// The pre-loaded "test-pipeline-version-3" CR is legacy-style (bare metadata.name, no spec.VersionName)
+	pv, err := store.GetPipelineVersion(DefaultFakePipelineIdTwo)
+	require.NoError(t, err)
+	assert.Equal(t, "test-pipeline-version-3", pv.Name)
+}
+
+func TestBackwardCompat_GetPipelineVersionByName_LegacyCR_WrongPipeline(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v2beta1.AddToScheme(scheme))
+
+	// Pipeline that owns the version
+	ownerPipeline := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdTwo,
+			Name:      "owner-pipeline",
+			Namespace: "Test",
+		},
+	}
+	// A different pipeline that does NOT own the version
+	otherPipeline := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdThree,
+			Name:      "other-pipeline",
+			Namespace: "Test",
+		},
+	}
+	// Legacy-style CR belonging to ownerPipeline
+	oldVersion := &v2beta1.PipelineVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdFour,
+			Name:      "shared-version-name",
+			Namespace: "Test",
+			Labels: map[string]string{
+				"pipelines.kubeflow.org/pipeline-id": DefaultFakePipelineIdTwo,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: v2beta1.GroupVersion.String(),
+					Kind:       "Pipeline",
+					UID:        DefaultFakePipelineIdTwo,
+					Name:       "owner-pipeline",
+				},
+			},
+		},
+		Spec: v2beta1.PipelineVersionSpec{
+			PipelineName: "owner-pipeline",
+			PipelineSpec: getBasicPipelineSpec(),
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ownerPipeline, otherPipeline, oldVersion).
+		Build()
+
+	store := NewPipelineStoreKubernetes(k8sClient, k8sClient)
+
+	// Looking up with the wrong pipeline should fail with NotFound
+	_, err := store.GetPipelineVersionByName(DefaultFakePipelineIdThree, "shared-version-name")
+	require.NotNil(t, err)
+	assert.Equal(t, codes.NotFound, err.(*util.UserError).ExternalStatusCode())
+
+	// Looking up with the correct pipeline should succeed
+	pv, err := store.GetPipelineVersionByName(DefaultFakePipelineIdTwo, "shared-version-name")
+	require.NoError(t, err)
+	assert.Equal(t, "shared-version-name", pv.Name)
+}
+
+func TestBackwardCompat_GetPipelineVersionByName_OwnerRefLabelMismatch(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v2beta1.AddToScheme(scheme))
+
+	pipelineA := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdTwo,
+			Name:      "pipeline-a",
+			Namespace: "Test",
+		},
+	}
+	pipelineB := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdThree,
+			Name:      "pipeline-b",
+			Namespace: "Test",
+		},
+	}
+	// CR with OwnerReference pointing to pipeline A but label edited to pipeline B
+	mismatchVersion := &v2beta1.PipelineVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdFour,
+			Name:      "mismatch-version",
+			Namespace: "Test",
+			Labels: map[string]string{
+				"pipelines.kubeflow.org/pipeline-id": DefaultFakePipelineIdThree,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: v2beta1.GroupVersion.String(),
+					Kind:       "Pipeline",
+					UID:        DefaultFakePipelineIdTwo,
+					Name:       "pipeline-a",
+				},
+			},
+		},
+		Spec: v2beta1.PipelineVersionSpec{
+			PipelineName: "pipeline-a",
+			PipelineSpec: getBasicPipelineSpec(),
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pipelineA, pipelineB, mismatchVersion).
+		Build()
+
+	store := NewPipelineStoreKubernetes(k8sClient, k8sClient)
+
+	// OwnerRef points to A, label points to B. Querying with B should reject
+	// because ownership is determined by OwnerReferences.
+	_, err := store.GetPipelineVersionByName(DefaultFakePipelineIdThree, "mismatch-version")
+	require.NotNil(t, err)
+	assert.Equal(t, codes.NotFound, err.(*util.UserError).ExternalStatusCode())
+
+	// Querying with A (the true owner) should succeed
+	pv, err := store.GetPipelineVersionByName(DefaultFakePipelineIdTwo, "mismatch-version")
+	require.NoError(t, err)
+	assert.Equal(t, "mismatch-version", pv.Name)
+}
+
+func TestBackwardCompat_ListPipelineVersions_MixedCRs(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	store := NewPipelineStoreKubernetes(getClient())
+
+	// The pre-loaded "test-pipeline-version-3" is legacy-style (bare name, under DefaultFakePipelineIdTwo).
+	// Create a new-style version under the same pipeline.
+	_, err := store.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "new-style-version",
+		PipelineId:   DefaultFakePipelineIdTwo,
+		PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+	})
+	require.NoError(t, err)
+
+	options := list.EmptyOptions()
+	versions, total, _, err := store.ListPipelineVersions(DefaultFakePipelineIdTwo, options, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, total)
+
+	// Both old and new versions should have correct bare names
+	names := make([]string, len(versions))
+	for i, v := range versions {
+		names[i] = v.Name
+	}
+	assert.Contains(t, names, "test-pipeline-version-3")
+	assert.Contains(t, names, "new-style-version")
+}
+
+func TestBackwardCompat_GetLatestPipelineVersion_MixedCRs(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	store := NewPipelineStoreKubernetes(getClient())
+
+	// Create a new-style version (will have a later creation timestamp)
+	_, err := store.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "new-latest-version",
+		PipelineId:   DefaultFakePipelineIdTwo,
+		PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+	})
+	require.NoError(t, err)
+
+	latest, err := store.GetLatestPipelineVersion(DefaultFakePipelineIdTwo)
+	require.NoError(t, err)
+	assert.Equal(t, "new-latest-version", latest.Name)
+}
+
+func TestBackwardCompat_DeletePipelineVersion_LegacyCR(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	store := NewPipelineStoreKubernetes(getClient())
+
+	// Delete legacy-style CR by UUID
+	err := store.DeletePipelineVersion(DefaultFakePipelineIdTwo)
+	require.NoError(t, err)
+
+	// Verify it's gone
+	_, err = store.GetPipelineVersion(DefaultFakePipelineIdTwo)
+	require.NotNil(t, err)
+	assert.Equal(t, err.(*util.UserError).ExternalStatusCode(), codes.NotFound)
+}
+
+func TestCreatePipelineVersion_DuplicateUnderSamePipeline(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	store := NewPipelineStoreKubernetes(getClient())
+
+	pipeline, err := store.CreatePipeline(&model.Pipeline{
+		Name:      "dup-test-pipeline",
+		Namespace: "Test",
+	})
+	require.NoError(t, err)
+
+	_, err = store.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "v1",
+		PipelineId:   pipeline.UUID,
+		PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+	})
+	require.NoError(t, err)
+
+	// Second creation with same name under same pipeline should fail
+	_, err = store.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "v1",
+		PipelineId:   pipeline.UUID,
+		PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+	})
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "already exist")
+}
+
+func TestCreatePipelineAndPipelineVersion_SameVersionNameDifferentPipelines(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	store := NewPipelineStoreKubernetes(getClient())
+
+	_, _, err := store.CreatePipelineAndPipelineVersion(
+		&model.Pipeline{Name: "atomic-pipeline-a"},
+		&model.PipelineVersion{
+			Name:         "initial",
+			PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+		},
+	)
+	require.NoError(t, err)
+
+	_, _, err = store.CreatePipelineAndPipelineVersion(
+		&model.Pipeline{Name: "atomic-pipeline-b"},
+		&model.PipelineVersion{
+			Name:         "initial",
+			PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+		},
+	)
+	require.NoError(t, err)
+}
+
+func TestCreatePipelineVersion_HyphenCollision(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v2beta1.AddToScheme(scheme))
+
+	pipelineFoo := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdThree,
+			Name:      "foo",
+			Namespace: "Test",
+		},
+	}
+	pipelineFooBar := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdFour,
+			Name:      "foo-bar",
+			Namespace: "Test",
+		},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pipelineFoo, pipelineFooBar).
+		Build()
+
+	store := NewPipelineStoreKubernetes(k8sClient, k8sClient)
+
+	// Pipeline "foo" + version "bar-baz" → composite "foo-bar-baz"
+	_, err := store.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "bar-baz",
+		PipelineId:   DefaultFakePipelineIdThree,
+		PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+	})
+	require.NoError(t, err)
+
+	// Pipeline "foo-bar" + version "baz" → also composite "foo-bar-baz"
+	// Known limitation: this collides because both produce the same composite K8s name
+	_, err = store.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "baz",
+		PipelineId:   DefaultFakePipelineIdFour,
+		PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+	})
+	require.NotNil(t, err, "Expected collision due to identical composite K8s names")
+	assert.Contains(t, err.Error(), "already exist")
+	assert.Contains(t, err.Error(), "foo-bar-baz")
+}
+
+func TestCreatePipelineVersion_DuplicateLegacyBareName(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v2beta1.AddToScheme(scheme))
+
+	pipeline := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdThree,
+			Name:      "my-pipeline",
+			Namespace: "Test",
+		},
+	}
+
+	// Pre-seed a legacy bare-name CR "v1" owned by the same pipeline
+	legacyVersion := &v2beta1.PipelineVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "v1",
+			Namespace: "Test",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: v2beta1.GroupVersion.String(),
+					Kind:       "Pipeline",
+					UID:        DefaultFakePipelineIdThree,
+					Name:       "my-pipeline",
+				},
+			},
+		},
+		Spec: v2beta1.PipelineVersionSpec{
+			PipelineSpec: getBasicPipelineSpec(),
+			PipelineName: "my-pipeline",
+			VersionName:  "v1",
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pipeline, legacyVersion).
+		Build()
+
+	store := NewPipelineStoreKubernetes(k8sClient, k8sClient)
+
+	// Creating a new version "v1" under the same pipeline should fail,
+	// even though the composite K8s name "my-pipeline-v1" differs from legacy "v1"
+	_, err := store.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "v1",
+		PipelineId:   DefaultFakePipelineIdThree,
+		PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+	})
+	require.NotNil(t, err, "Expected duplicate rejection against legacy bare-name CR")
+	assert.Contains(t, err.Error(), "already exist")
+}
+
+func TestCreatePipelineVersion_TransientErrorDuringLookup(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v2beta1.AddToScheme(scheme))
+
+	pipeline := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdThree,
+			Name:      "my-pipeline",
+			Namespace: "Test",
+		},
+	}
+
+	legacyVersion := &v2beta1.PipelineVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "v1",
+			Namespace: "Test",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: v2beta1.GroupVersion.String(),
+					Kind:       "Pipeline",
+					UID:        DefaultFakePipelineIdThree,
+					Name:       "my-pipeline",
+				},
+			},
+		},
+		Spec: v2beta1.PipelineVersionSpec{
+			PipelineSpec: getBasicPipelineSpec(),
+			PipelineName: "my-pipeline",
+			VersionName:  "v1",
+		},
+	}
+
+	// Inject a transient error on the first Get call (the one inside
+	// getPipelineVersionByNameInNamespace during the pre-create collision check).
+	getCallCount := 0
+	transientError := fmt.Errorf("simulated transient API server error")
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pipeline, legacyVersion).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*v2beta1.PipelineVersion); ok {
+					getCallCount++
+					if getCallCount == 1 {
+						return transientError
+					}
+				}
+				return client.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	store := NewPipelineStoreKubernetes(k8sClient, k8sClient)
+
+	_, err := store.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "v1",
+		PipelineId:   DefaultFakePipelineIdThree,
+		PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+	})
+	require.NotNil(t, err, "Expected error to propagate from transient lookup failure")
+	assert.Contains(t, err.Error(), "simulated transient")
+}
+
+func TestGetPipelineVersionByName_InvalidPipelineId(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	store := NewPipelineStoreKubernetes(getClient())
+
+	_, err := store.GetPipelineVersionByName("nonexistent-pipeline-id", "v1.0")
+	require.NotNil(t, err)
+	assert.Equal(t, codes.NotFound, err.(*util.UserError).ExternalStatusCode())
+}
+
+func TestGetPipelineVersionByName_HyphenCollisionFallthrough(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v2beta1.AddToScheme(scheme))
+
+	// Pipeline "foo" and pipeline "foo-bar"
+	pipelineFoo := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdThree,
+			Name:      "foo",
+			Namespace: "Test",
+		},
+	}
+	pipelineFooBar := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdFour,
+			Name:      "foo-bar",
+			Namespace: "Test",
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pipelineFoo, pipelineFooBar).
+		Build()
+
+	store := NewPipelineStoreKubernetes(k8sClient, k8sClient)
+
+	// Create "foo" + "bar-baz" → composite "foo-bar-baz", owned by pipelineFoo
+	_, err := store.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "bar-baz",
+		PipelineId:   DefaultFakePipelineIdThree,
+		PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+	})
+	require.NoError(t, err)
+
+	// Lookup "foo-bar" + "baz" → composite is also "foo-bar-baz", but owned by
+	// pipelineFoo, not pipelineFooBar. The code should detect the ownership
+	// mismatch and fall through to bare-name lookup, which also fails → NotFound.
+	_, err = store.GetPipelineVersionByName(DefaultFakePipelineIdFour, "baz")
+	require.NotNil(t, err)
+	assert.Equal(t, codes.NotFound, err.(*util.UserError).ExternalStatusCode())
+}
+
+func TestGetPipelineVersionByName_HyphenCollisionFallbackSuccess(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v2beta1.AddToScheme(scheme))
+
+	pipelineFoo := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdThree,
+			Name:      "foo",
+			Namespace: "Test",
+		},
+	}
+	pipelineFooBar := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdFour,
+			Name:      "foo-bar",
+			Namespace: "Test",
+		},
+	}
+
+	// Legacy bare-name CR owned by pipeline "foo-bar"
+	legacyVersion := &v2beta1.PipelineVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "legacy-version-uid",
+			Name:      "baz",
+			Namespace: "Test",
+			Labels: map[string]string{
+				"pipelines.kubeflow.org/pipeline-id": DefaultFakePipelineIdFour,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: v2beta1.GroupVersion.String(),
+					Kind:       "Pipeline",
+					UID:        DefaultFakePipelineIdFour,
+					Name:       "foo-bar",
+				},
+			},
+		},
+		Spec: v2beta1.PipelineVersionSpec{
+			PipelineName: "foo-bar",
+			PipelineSpec: getBasicPipelineSpec(),
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pipelineFoo, pipelineFooBar, legacyVersion).
+		Build()
+
+	store := NewPipelineStoreKubernetes(k8sClient, k8sClient)
+
+	// Pipeline "foo" + version "bar-baz" → composite "foo-bar-baz"
+	_, err := store.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "bar-baz",
+		PipelineId:   DefaultFakePipelineIdThree,
+		PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+	})
+	require.NoError(t, err)
+
+	// Lookup "foo-bar" + "baz": composite "foo-bar-baz" exists but is owned by
+	// pipeline "foo". The code detects the ownership mismatch, falls back to
+	// bare-name "baz", and finds the legacy CR owned by pipeline "foo-bar".
+	pv, err := store.GetPipelineVersionByName(DefaultFakePipelineIdFour, "baz")
+	require.NoError(t, err)
+	assert.Equal(t, "baz", pv.Name)
+	assert.Equal(t, DefaultFakePipelineIdFour, pv.PipelineId)
+	assert.Equal(t, "legacy-version-uid", pv.UUID)
+}
+
+func TestCreatePipelineAndPipelineVersion_InvalidVersionName(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	store := NewPipelineStoreKubernetes(getClient())
+
+	// Invalid version name should fail before creating the pipeline (no orphan)
+	_, _, err := store.CreatePipelineAndPipelineVersion(
+		&model.Pipeline{Name: "should-not-be-created"},
+		&model.PipelineVersion{
+			Name:         "INVALID-UPPERCASE",
+			PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+		},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid pipeline version name")
+
+	// Verify the pipeline was NOT created
+	_, err = store.GetPipelineByNameAndNamespace("should-not-be-created", "")
+	require.NotNil(t, err)
+	assert.Equal(t, codes.NotFound, err.(*util.UserError).ExternalStatusCode())
+}
+
+func TestGetPipelineVersionByName_DifferentNamespace(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "DefaultNS")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	multiUser := viper.Get("MULTIUSER")
+	viper.Set("MULTIUSER", "true")
+	defer viper.Set("MULTIUSER", multiUser)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v2beta1.AddToScheme(scheme))
+
+	pipeline := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdThree,
+			Name:      "user-pipeline",
+			Namespace: "UserNS",
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pipeline).
+		Build()
+
+	store := NewPipelineStoreKubernetes(k8sClient, k8sClient)
+
+	_, err := store.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "v1",
+		PipelineId:   DefaultFakePipelineIdThree,
+		PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+	})
+	require.NoError(t, err)
+
+	// POD_NAMESPACE is "DefaultNS" but the version lives in "UserNS"
+	version, err := store.GetPipelineVersionByName(DefaultFakePipelineIdThree, "v1")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", version.Name)
+	assert.Equal(t, DefaultFakePipelineIdThree, version.PipelineId)
+}
+
+func getClientWithTwoPipelines() (client.Client, client.Client) {
+	scheme := runtime.NewScheme()
+	err := v2beta1.AddToScheme(scheme)
+	if err != nil {
+		glog.Fatalf("Failed to add to scheme: %v", err)
+	}
+
+	pipelineAlpha := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdThree,
+			Name:      "pipeline-alpha",
+			Namespace: "Test",
+		},
+		Spec: v2beta1.PipelineSpec{
+			Description: "Pipeline Alpha",
+		},
+	}
+
+	pipelineBeta := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       DefaultFakePipelineIdFour,
+			Name:      "pipeline-beta",
+			Namespace: "Test",
+		},
+		Spec: v2beta1.PipelineSpec{
+			Description: "Pipeline Beta",
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pipelineAlpha, pipelineBeta).
+		Build()
+
+	return k8sClient, k8sClient
+}

--- a/backend/src/apiserver/storage/pipeline_store_kubernetes_test.go
+++ b/backend/src/apiserver/storage/pipeline_store_kubernetes_test.go
@@ -443,7 +443,8 @@ func TestGetK8sPipelineVersionByName(t *testing.T) {
 
 	store := NewPipelineStoreKubernetes(getClient())
 
-	pipelineVersion, err := store.GetPipelineVersionByName("test-pipeline-version-3")
+	// Legacy-style CR (bare metadata.name) — should be found via bare-name fallback
+	pipelineVersion, err := store.GetPipelineVersionByName(DefaultFakePipelineIdTwo, "test-pipeline-version-3")
 	require.Nil(t, err, "Failed to get Pipeline: %v", err)
 	require.Equalf(t, pipelineVersion.Name, "test-pipeline-version-3", pipelineVersion.Name)
 }
@@ -559,6 +560,7 @@ func TestCreateK8sPipelineVersion_InvalidName_Standalone(t *testing.T) {
 	require.NotNil(t, err, "Expected error for invalid pipeline version name")
 	assert.Contains(t, err.Error(), "Invalid pipeline version name")
 	assert.Contains(t, err.Error(), "display_name")
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
 }
 
 // getBasicPipelineSpec returns a basic PipelineSpec for testing purposes
@@ -590,6 +592,51 @@ root:
     tasks: {}
 schemaVersion: "2.1.0"
 sdkVersion: kfp-2.13.0`
+}
+
+func TestGetPipelineVersionByName_CompositeNameLookup(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	store := NewPipelineStoreKubernetes(getClientWithTwoPipelines())
+
+	_, err := store.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "v1.0",
+		PipelineId:   DefaultFakePipelineIdThree,
+		PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+	})
+	require.NoError(t, err)
+
+	_, err = store.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "v1.0",
+		PipelineId:   DefaultFakePipelineIdFour,
+		PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
+	})
+	require.NoError(t, err)
+
+	// Look up each by pipeline ID + bare version name
+	versionA, err := store.GetPipelineVersionByName(DefaultFakePipelineIdThree, "v1.0")
+	require.NoError(t, err)
+	assert.Equal(t, "v1.0", versionA.Name)
+	assert.Equal(t, DefaultFakePipelineIdThree, versionA.PipelineId)
+
+	versionB, err := store.GetPipelineVersionByName(DefaultFakePipelineIdFour, "v1.0")
+	require.NoError(t, err)
+	assert.Equal(t, "v1.0", versionB.Name)
+	assert.Equal(t, DefaultFakePipelineIdFour, versionB.PipelineId)
+}
+
+func TestGetPipelineVersionByName_NotFound(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	store := NewPipelineStoreKubernetes(getClient())
+
+	_, err := store.GetPipelineVersionByName(DefaultFakePipelineIdTwo, "nonexistent")
+	require.NotNil(t, err)
+	assert.Equal(t, err.(*util.UserError).ExternalStatusCode(), codes.NotFound)
 }
 
 func getClient() (client.Client, client.Client) {
@@ -653,12 +700,16 @@ func getClient() (client.Client, client.Client) {
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					UID: DefaultFakePipelineIdTwo,
+					APIVersion: v2beta1.GroupVersion.String(),
+					Kind:       "Pipeline",
+					UID:        DefaultFakePipelineIdTwo,
+					Name:       "test-pipeline-3",
 				},
 			},
 		},
 		Spec: v2beta1.PipelineVersionSpec{
 			Description:  "Test Pipeline Version 1 Description",
+			PipelineName: "test-pipeline-3",
 			PipelineSpec: getBasicPipelineSpec(),
 		},
 	}

--- a/backend/src/apiserver/storage/pipeline_store_test.go
+++ b/backend/src/apiserver/storage/pipeline_store_test.go
@@ -2105,3 +2105,81 @@ func TestUpdatePipelineFields_DisplayNameAndTags(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, tags, loadedTags)
 }
+
+func TestGetPipelineVersionByName_SameNameDifferentPipelines(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	pipelineStore := NewPipelineStore(
+		db,
+		util.NewFakeTimeForEpoch(),
+		util.NewFakeUUIDGeneratorOrFatal(DefaultFakePipelineId, nil))
+
+	pipelineA, err := pipelineStore.CreatePipeline(createPipeline("pipeline-a", "", ""))
+	assert.Nil(t, err)
+
+	pipelineStore.uuid = util.NewFakeUUIDGeneratorOrFatal(DefaultFakePipelineIdTwo, nil)
+	pipelineB, err := pipelineStore.CreatePipeline(createPipeline("pipeline-b", "", ""))
+	assert.Nil(t, err)
+
+	pipelineStore.uuid = util.NewFakeUUIDGeneratorOrFatal(DefaultFakePipelineIdThree, nil)
+	_, err = pipelineStore.CreatePipelineVersion(
+		createPipelineVersion(pipelineA.UUID, "v1.0", "", "", "", ""))
+	assert.Nil(t, err)
+
+	pipelineStore.uuid = util.NewFakeUUIDGeneratorOrFatal(DefaultFakePipelineIdFour, nil)
+	_, err = pipelineStore.CreatePipelineVersion(
+		createPipelineVersion(pipelineB.UUID, "v1.0", "", "", "", ""))
+	assert.Nil(t, err)
+
+	versionA, err := pipelineStore.GetPipelineVersionByName(pipelineA.UUID, "v1.0")
+	assert.Nil(t, err)
+	assert.Equal(t, "v1.0", versionA.Name)
+	assert.Equal(t, pipelineA.UUID, versionA.PipelineId)
+
+	versionB, err := pipelineStore.GetPipelineVersionByName(pipelineB.UUID, "v1.0")
+	assert.Nil(t, err)
+	assert.Equal(t, "v1.0", versionB.Name)
+	assert.Equal(t, pipelineB.UUID, versionB.PipelineId)
+}
+
+func TestGetPipelineVersionByName_SQL_NotFound(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	pipelineStore := NewPipelineStore(
+		db,
+		util.NewFakeTimeForEpoch(),
+		util.NewFakeUUIDGeneratorOrFatal(DefaultFakePipelineId, nil))
+
+	_, err := pipelineStore.CreatePipeline(createPipeline("pipeline-a", "", ""))
+	assert.Nil(t, err)
+
+	pipelineStore.uuid = util.NewFakeUUIDGeneratorOrFatal(DefaultFakePipelineIdTwo, nil)
+	_, err = pipelineStore.CreatePipelineVersion(
+		createPipelineVersion(DefaultFakePipelineId, "v1.0", "", "", "", ""))
+	assert.Nil(t, err)
+
+	_, err = pipelineStore.GetPipelineVersionByName(DefaultFakePipelineId, "nonexistent")
+	assert.NotNil(t, err)
+	assert.Equal(t, codes.NotFound, err.(*util.UserError).ExternalStatusCode())
+}
+
+func TestGetPipelineVersionByName_WrongPipeline(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	pipelineStore := NewPipelineStore(
+		db,
+		util.NewFakeTimeForEpoch(),
+		util.NewFakeUUIDGeneratorOrFatal(DefaultFakePipelineId, nil))
+
+	_, err := pipelineStore.CreatePipeline(createPipeline("pipeline-a", "", ""))
+	assert.Nil(t, err)
+
+	pipelineStore.uuid = util.NewFakeUUIDGeneratorOrFatal(DefaultFakePipelineIdTwo, nil)
+	_, err = pipelineStore.CreatePipelineVersion(
+		createPipelineVersion(DefaultFakePipelineId, "v1.0", "", "", "", ""))
+	assert.Nil(t, err)
+
+	_, err = pipelineStore.GetPipelineVersionByName("nonexistent-pipeline-id", "v1.0")
+	assert.NotNil(t, err)
+	assert.Equal(t, codes.NotFound, err.(*util.UserError).ExternalStatusCode())
+}

--- a/backend/src/crd/kubernetes/v2beta1/pipeline_version_name.go
+++ b/backend/src/crd/kubernetes/v2beta1/pipeline_version_name.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2beta1
+
+import (
+	"strings"
+
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// PipelineVersionName encapsulates the DNS-1123 validated composite or bare name for a PipelineVersion CR.
+// +kubebuilder:object:generate=false
+type PipelineVersionName struct {
+	pipelineName string
+	versionName  string
+}
+
+func NewPipelineVersionName(pipelineName, versionName string) (PipelineVersionName, error) {
+	if errs := validation.IsDNS1123Subdomain(versionName); len(errs) > 0 {
+		return PipelineVersionName{}, util.NewInvalidInputError(
+			"Invalid pipeline version name %q: %s. Use 'display_name' for human-readable labels",
+			versionName, strings.Join(errs, "; "),
+		)
+	}
+	if pipelineName != "" {
+		compositeName := pipelineName + "-" + versionName
+		if errs := validation.IsDNS1123Subdomain(compositeName); len(errs) > 0 {
+			return PipelineVersionName{}, util.NewInvalidInputError(
+				"The combined pipeline and version name %q exceeds the Kubernetes 253-character naming limit: %s",
+				compositeName, strings.Join(errs, "; "),
+			)
+		}
+	}
+	return PipelineVersionName{pipelineName: pipelineName, versionName: versionName}, nil
+}
+
+func (n PipelineVersionName) Name() string {
+	if n.pipelineName != "" {
+		return n.pipelineName + "-" + n.versionName
+	}
+	return n.versionName
+}

--- a/backend/src/crd/kubernetes/v2beta1/pipeline_version_name_test.go
+++ b/backend/src/crd/kubernetes/v2beta1/pipeline_version_name_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2beta1
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPipelineVersionName_CompositeValid(t *testing.T) {
+	pvName, err := NewPipelineVersionName("my-pipeline", "v1")
+	require.NoError(t, err)
+	assert.Equal(t, "my-pipeline-v1", pvName.Name())
+}
+
+func TestNewPipelineVersionName_BareValid(t *testing.T) {
+	pvName, err := NewPipelineVersionName("", "v1")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", pvName.Name())
+}
+
+func TestNewPipelineVersionName_InvalidBareName(t *testing.T) {
+	_, err := NewPipelineVersionName("my-pipeline", "UPPERCASE")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid pipeline version name")
+
+	_, err = NewPipelineVersionName("my-pipeline", "-starts-with-hyphen")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid pipeline version name")
+}
+
+func TestNewPipelineVersionName_CompositeTooLong(t *testing.T) {
+	versionName := strings.Repeat("v", 253)
+	_, err := NewPipelineVersionName("p", versionName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Kubernetes 253-character naming limit")
+}

--- a/backend/src/crd/kubernetes/v2beta1/pipelineversion_types.go
+++ b/backend/src/crd/kubernetes/v2beta1/pipelineversion_types.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/template"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"google.golang.org/protobuf/encoding/protojson"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,7 +36,10 @@ type PipelineVersionSpec struct {
 	Description   string `json:"description,omitempty"`
 	CodeSourceURL string `json:"codeSourceURL,omitempty"`
 	PipelineName  string `json:"pipelineName,omitempty"`
-	DisplayName   string `json:"displayName,omitempty"`
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
+	VersionName string `json:"versionName,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
@@ -95,6 +99,19 @@ type PipelineVersionList struct {
 }
 
 func FromPipelineVersionModel(pipeline model.Pipeline, pipelineVersion model.PipelineVersion) (*PipelineVersion, error) {
+	if pipelineVersion.Name == "" {
+		return nil, util.NewInvalidInputError("pipeline version name must not be empty")
+	}
+
+	pipelineName := pipeline.Name
+	if pipelineName == pipelineVersion.Name {
+		pipelineName = ""
+	}
+	pvName, err := NewPipelineVersionName(pipelineName, pipelineVersion.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	v2Spec, err := template.NewV2SpecTemplate([]byte(string(pipelineVersion.PipelineSpec)), template.TemplateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse the pipeline spec: %w", err)
@@ -137,7 +154,7 @@ func FromPipelineVersionModel(pipeline model.Pipeline, pipelineVersion model.Pip
 
 	return &PipelineVersion{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      pipelineVersion.Name,
+			Name:      pvName.Name(),
 			Namespace: pipeline.Namespace,
 			UID:       types.UID(pipelineVersion.UUID),
 			Labels: map[string]string{
@@ -158,6 +175,7 @@ func FromPipelineVersionModel(pipeline model.Pipeline, pipelineVersion model.Pip
 			PipelineSpec:    pipelineSpec,
 			PlatformSpec:    platformSpec,
 			PipelineName:    pipeline.Name,
+			VersionName:     pipelineVersion.Name,
 			CodeSourceURL:   pipelineVersion.CodeSourceUrl,
 			PipelineSpecURI: string(pipelineVersion.PipelineSpecURI),
 			Tags:            pipelineVersion.Tags,
@@ -210,15 +228,20 @@ func (p *PipelineVersion) ToModel() (*model.PipelineVersion, error) {
 		}
 	}
 
+	versionName := p.Spec.VersionName
+	if versionName == "" {
+		versionName = p.Name
+	}
+
 	displayName := p.Spec.DisplayName
 	if displayName == "" {
-		displayName = p.Name
+		displayName = versionName
 	}
 
 	return &model.PipelineVersion{
 		UUID:            string(p.UID),
 		CreatedAtInSec:  p.CreationTimestamp.Unix(),
-		Name:            p.Name,
+		Name:            versionName,
 		DisplayName:     displayName,
 		Parameters:      "",
 		PipelineId:      string(pipelineID),
@@ -292,6 +315,9 @@ func (p *PipelineVersion) GetField(name string) interface{} {
 	case "pipeline_versions.pipeline_version_id":
 		return p.UID
 	case "pipeline_versions.Name":
+		if p.Spec.VersionName != "" {
+			return p.Spec.VersionName
+		}
 		return p.Name
 	case "pipeline_versions.Status":
 		if len(p.Status.Conditions) > 0 {

--- a/backend/src/crd/kubernetes/v2beta1/pipelineversion_types_test.go
+++ b/backend/src/crd/kubernetes/v2beta1/pipelineversion_types_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,11 +61,14 @@ sdkVersion: kfp-2.13.0`,
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 
-	// Check ObjectMeta
-	assert.Equal(t, "test-version", result.Name)
+	// Check ObjectMeta — metadata.name should be composite: {pipelineName}-{versionName}
+	assert.Equal(t, "test-pipeline-test-version", result.Name)
 	assert.Equal(t, "default", result.Namespace)
 	assert.Equal(t, types.UID("version-456"), result.UID)
 	assert.Equal(t, "pipeline-123", result.Labels["pipelines.kubeflow.org/pipeline-id"])
+
+	// Check that the bare version name is stored in spec.VersionName
+	assert.Equal(t, "test-version", result.Spec.VersionName)
 
 	// Check OwnerReferences
 	require.Len(t, result.OwnerReferences, 1)
@@ -726,6 +730,11 @@ platforms:
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 
+	// metadata.name should be composite
+	assert.Equal(t, "hello-world-hello-world-v1", result.Name)
+	// spec.VersionName should store the bare version name
+	assert.Equal(t, "hello-world-v1", result.Spec.VersionName)
+
 	// Convert back to model
 	roundTripModel, err := result.ToModel()
 	require.NoError(t, err)
@@ -763,10 +772,186 @@ platforms:
 			"YAML document %d should be deeply equal after round-trip", i)
 	}
 
-	// Verify basic metadata is preserved
+	// Verify basic metadata is preserved — Name should be the bare version name, not composite
 	assert.Equal(t, "version-456", roundTripModel.UUID)
 	assert.Equal(t, "hello-world-v1", roundTripModel.Name)
 	assert.Equal(t, "Hello World Pipeline v1", roundTripModel.DisplayName)
 	assert.Equal(t, "A simple hello world pipeline with workspace configuration", string(roundTripModel.Description))
 	assert.Equal(t, "pipeline-123", roundTripModel.PipelineId)
+}
+
+func TestToModel_UsesVersionName(t *testing.T) {
+	pipelineVersion := &PipelineVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pipeline-v1",
+			Namespace: "default",
+			UID:       "version-789",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: GroupVersion.String(),
+					Kind:       "Pipeline",
+					UID:        "pipeline-123",
+					Name:       "my-pipeline",
+				},
+			},
+		},
+		Spec: PipelineVersionSpec{
+			DisplayName:  "Version 1",
+			VersionName:  "v1",
+			PipelineName: "my-pipeline",
+			PipelineSpec: IRSpec{
+				Value: map[string]interface{}{
+					"pipelineInfo":  map[string]interface{}{"name": "my-pipeline"},
+					"root":          map[string]interface{}{"dag": map[string]interface{}{"tasks": map[string]interface{}{}}},
+					"schemaVersion": "2.1.0",
+				},
+			},
+		},
+	}
+
+	result, err := pipelineVersion.ToModel()
+	require.NoError(t, err)
+
+	// Name should come from spec.VersionName, not metadata.name
+	assert.Equal(t, "v1", result.Name)
+	assert.Equal(t, "Version 1", result.DisplayName)
+}
+
+func TestToModel_FallsBackToMetadataName(t *testing.T) {
+	pipelineVersion := &PipelineVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "old-version",
+			Namespace: "default",
+			UID:       "version-old",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: GroupVersion.String(),
+					Kind:       "Pipeline",
+					UID:        "pipeline-123",
+					Name:       "my-pipeline",
+				},
+			},
+		},
+		Spec: PipelineVersionSpec{
+			DisplayName:  "Old Version",
+			PipelineName: "my-pipeline",
+			PipelineSpec: IRSpec{
+				Value: map[string]interface{}{
+					"pipelineInfo":  map[string]interface{}{"name": "my-pipeline"},
+					"root":          map[string]interface{}{"dag": map[string]interface{}{"tasks": map[string]interface{}{}}},
+					"schemaVersion": "2.1.0",
+				},
+			},
+		},
+	}
+
+	result, err := pipelineVersion.ToModel()
+	require.NoError(t, err)
+
+	// No spec.VersionName set — should fall back to metadata.name
+	assert.Equal(t, "old-version", result.Name)
+}
+
+func TestGetField_ReturnsVersionName(t *testing.T) {
+	pipelineVersion := &PipelineVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pipeline-v1",
+			Namespace: "default",
+			UID:       "version-789",
+		},
+		Spec: PipelineVersionSpec{
+			VersionName: "v1",
+		},
+	}
+
+	// Should return the bare version name from spec, not metadata.name
+	assert.Equal(t, "v1", pipelineVersion.GetField("pipeline_versions.Name"))
+}
+
+func TestGetField_FallsBackToMetadataName(t *testing.T) {
+	pipelineVersion := &PipelineVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "old-version",
+			Namespace: "default",
+			UID:       "version-old",
+		},
+		Spec: PipelineVersionSpec{},
+	}
+
+	// No spec.VersionName — should fall back to metadata.name
+	assert.Equal(t, "old-version", pipelineVersion.GetField("pipeline_versions.Name"))
+}
+
+func TestFromPipelineVersionModel_EmptyVersionName(t *testing.T) {
+	_, err := FromPipelineVersionModel(
+		model.Pipeline{Name: "my-pipeline", Namespace: "default", UUID: "pipeline-123"},
+		model.PipelineVersion{Name: ""},
+	)
+	var userError *util.UserError
+	require.ErrorAs(t, err, &userError)
+	assert.Contains(t, err.Error(), "pipeline version name must not be empty")
+}
+
+func TestFromPipelineVersionModel_InvalidDNSVersionName(t *testing.T) {
+	_, err := FromPipelineVersionModel(
+		model.Pipeline{Name: "my-pipeline", Namespace: "default", UUID: "pipeline-123"},
+		model.PipelineVersion{
+			Name: "UPPERCASE",
+			PipelineSpec: `pipelineInfo:
+  name: test-pipeline
+root:
+  dag:
+    tasks: {}
+schemaVersion: "2.1.0"
+sdkVersion: kfp-2.13.0`,
+		},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid pipeline version name")
+}
+
+func TestFromPipelineVersionModel_CompositeTooLong(t *testing.T) {
+	_, err := FromPipelineVersionModel(
+		model.Pipeline{Name: "my-pipeline", Namespace: "default", UUID: "pipeline-123"},
+		model.PipelineVersion{
+			Name: strings.Repeat("v", 253),
+			PipelineSpec: `pipelineInfo:
+  name: test-pipeline
+root:
+  dag:
+    tasks: {}
+schemaVersion: "2.1.0"
+sdkVersion: kfp-2.13.0`,
+		},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Kubernetes 253-character naming limit")
+}
+
+func TestFromPipelineVersionModel_SameNameAsPipeline(t *testing.T) {
+	pipeline := model.Pipeline{
+		UUID:      "pipeline-123",
+		Name:      "my-pipeline",
+		Namespace: "default",
+	}
+
+	pipelineVersion := model.PipelineVersion{
+		UUID:       "version-456",
+		Name:       "my-pipeline",
+		PipelineId: "pipeline-123",
+		PipelineSpec: `pipelineInfo:
+  name: my-pipeline
+root:
+  dag:
+    tasks: {}
+schemaVersion: "2.1.0"
+sdkVersion: kfp-2.13.0`,
+	}
+
+	result, err := FromPipelineVersionModel(pipeline, pipelineVersion)
+	require.NoError(t, err)
+
+	// When version name matches pipeline name, metadata.name should be bare (not "my-pipeline-my-pipeline")
+	assert.Equal(t, "my-pipeline", result.Name, "expected bare name, not composite %q", result.Name)
+	assert.Equal(t, "my-pipeline", result.Spec.VersionName)
 }

--- a/manifests/kustomize/base/crds/pipelines.kubeflow.org_pipelineversions.yaml
+++ b/manifests/kustomize/base/crds/pipelines.kubeflow.org_pipelineversions.yaml
@@ -57,6 +57,10 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              versionName:
+                maxLength: 253
+                pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                type: string
             required:
             - pipelineSpec
             type: object


### PR DESCRIPTION
(cherry picked from commit 450482265b4c67154a2b84da23a1abd2334b9a6a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pipeline versions now track a separate `versionName`, improving name/display consistency and ensuring CRD and model values stay aligned.

* **Bug Fixes**
  * Improved pipeline-version discovery during restarts, including better handling across namespace changes and idempotent restarts.
  * Prevented incorrect version retrieval when the same version name exists in different pipelines by scoping lookups to the specific pipeline.
  * Enhanced Kubernetes pipeline-version naming and backward-compatible lookup/creation to avoid collisions and ensure correct ownership checks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->