### PR TITLE
UPSTREAM: <carry>: fix: re-establish port-forwarding after upgrade deploy in upgrade test

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -130,7 +130,23 @@ jobs:
           DEPLOYMENT_NAME="${{ steps.deploy.outputs.deployment_name }}"
           NAMESPACE="${{ env.NAMESPACE }}"
 
-          echo "Waiting for rollout of $DEPLOYMENT_NAME in $NAMESPACE..."
+          OLD_POD_UID=$(kubectl get pod -l app=$DEPLOYMENT_NAME -n $NAMESPACE -o jsonpath='{.items[0].metadata.uid}')
+          echo "Current pod UID: $OLD_POD_UID"
+
+          echo "Waiting for operator to roll the deployment..."
+          for i in $(seq 1 60); do
+            NEW_POD_UID=$(kubectl get pod -l app=$DEPLOYMENT_NAME -n $NAMESPACE -o jsonpath='{.items[0].metadata.uid}' 2>/dev/null || echo "")
+            if [ -n "$NEW_POD_UID" ] && [ "$NEW_POD_UID" != "$OLD_POD_UID" ]; then
+              echo "New pod detected (UID: $NEW_POD_UID) after $((i * 5))s"
+              break
+            fi
+            if [ $i -eq 60 ]; then
+              echo "Warning: Pod UID did not change after 300s, proceeding anyway"
+            fi
+            sleep 5
+          done
+
+          echo "Waiting for rollout to complete..."
           kubectl rollout status deployment/$DEPLOYMENT_NAME -n $NAMESPACE --timeout=300s
 
           echo "Waiting for pod to be ready..."

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -134,14 +134,15 @@ jobs:
           echo "Current pod UID: $OLD_POD_UID"
 
           echo "Waiting for operator to roll the deployment..."
-          for i in $(seq 1 60); do
+          for i in $(seq 1 36); do
             NEW_POD_UID=$(kubectl get pod -l app=$DEPLOYMENT_NAME -n $NAMESPACE -o jsonpath='{.items[0].metadata.uid}' 2>/dev/null || echo "")
             if [ -n "$NEW_POD_UID" ] && [ "$NEW_POD_UID" != "$OLD_POD_UID" ]; then
               echo "New pod detected (UID: $NEW_POD_UID) after $((i * 5))s"
               break
             fi
-            if [ $i -eq 60 ]; then
-              echo "Warning: Pod UID did not change after 300s, proceeding anyway"
+            if [ $i -eq 36 ]; then
+              echo "ERROR: Pod UID did not change after 180s — operator did not roll the deployment"
+              exit 1
             fi
             sleep 5
           done

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -122,9 +122,30 @@ jobs:
           skip_operator_deployment: ${{ env.SKIP_OPERATOR_DEPLOYMENT }}
           pod_to_pod_tls_enabled: ${{ matrix.tls_enabled }}
 
+      - name: Wait for upgrade rollout and re-establish port-forwarding
+        if: ${{ steps.deploy.outcome == 'success' }}
+        id: post-upgrade-port-forward
+        shell: bash
+        run: |
+          DEPLOYMENT_NAME="${{ steps.deploy.outputs.deployment_name }}"
+          NAMESPACE="${{ env.NAMESPACE }}"
+
+          echo "Waiting for rollout of $DEPLOYMENT_NAME in $NAMESPACE..."
+          kubectl rollout status deployment/$DEPLOYMENT_NAME -n $NAMESPACE --timeout=300s
+
+          echo "Waiting for pod to be ready..."
+          kubectl wait --for=condition=ready pod -l app=$DEPLOYMENT_NAME -n $NAMESPACE --timeout=120s --field-selector=status.phase=Running
+
+          echo "Killing stale port-forward processes..."
+          pkill -f "kubectl port-forward.*8888" || true
+          sleep 3
+
+          echo "Re-establishing port-forward..."
+          ./.github/resources/scripts/forward-port.sh "$NAMESPACE" "$DEPLOYMENT_NAME" 8888 8888
+
       - name: Verify Upgrade
         uses: ./.github/actions/test-and-report
-        if: ${{ steps.deploy.outcome == 'success' }}
+        if: ${{ steps.post-upgrade-port-forward.outcome == 'success' }}
         with:
           test_directory: ${{ env.TESTS_DIR }}
           test_label: "UpgradeVerification"


### PR DESCRIPTION
## Summary

- The upgrade test was flaky because the "Deploy from Branch" step sets `forward_port=false`, so no new port-forward is created after the upgrade. When the DSPA operator rolls the API server pods, the old port-forward dies, causing all "Verify Upgrade" tests to fail with connection refused/reset/EOF on `localhost:8888`.
- Adds a step between "Deploy from Branch" and "Verify Upgrade" that waits for the rollout to complete and re-establishes port-forwarding, following the same pattern used in `kfp-kubernetes-native-migration-tests.yaml`.
- Updates the "Verify Upgrade" condition to gate on the new step's success.

## Test plan

- [ ] Verify the upgrade test workflow passes on this PR (the workflow is triggered by changes to `.github/workflows/upgrade-test.yml`)
- [ ] Confirm the "Wait for upgrade rollout and re-establish port-forwarding" step logs show it waiting for rollout completion and setting up port-forward
- [ ] Confirm the "Verify Upgrade" step passes with 0 test failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the upgrade workflow to wait for the updated deployment to finish becoming ready before continuing.
  * Refreshed port forwarding after the upgrade to avoid stale connections during verification.
  * Updated verification to run only after the post-upgrade connection is successfully re-established.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->