### PR TITLE
UPSTREAM<carry>: fix to use runtime CA cert path for MLflow config in API server

### DIFF
--- a/backend/src/apiserver/plugins/mlflow/handler.go
+++ b/backend/src/apiserver/plugins/mlflow/handler.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/glog"
 	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	apiserverPlugins "github.com/kubeflow/pipelines/backend/src/apiserver/plugins"
 	commonplugins "github.com/kubeflow/pipelines/backend/src/common/plugins"
 	commonmlflow "github.com/kubeflow/pipelines/backend/src/common/plugins/mlflow"
@@ -125,7 +126,7 @@ func (h *Handler) OnBeforeRunCreation(ctx context.Context, run *apiserverPlugins
 	var runtimeTLS *commonplugins.TLSConfig
 	if runCfg.TLS != nil && runCfg.TLS.CABundlePath != "" {
 		runtimeTLS = &commonplugins.TLSConfig{
-			CABundlePath: runCfg.TLS.CABundlePath,
+			CABundlePath: common.CustomCaCertPath,
 		}
 	}
 	mlflowRuntimeConfig := commonmlflow.MLflowRuntimeConfig{

--- a/backend/src/apiserver/plugins/mlflow/handler_test.go
+++ b/backend/src/apiserver/plugins/mlflow/handler_test.go
@@ -238,7 +238,7 @@ func TestOnBeforeRunCreation_CABundlePath_Propagated(t *testing.T) {
 	var rtCfg commonmlflow.MLflowRuntimeConfig
 	require.NoError(t, json.Unmarshal([]byte(env[commonmlflow.EnvMLflowConfig]), &rtCfg))
 	require.NotNil(t, rtCfg.TLS)
-	assert.Equal(t, caBundlePath, rtCfg.TLS.CABundlePath)
+	assert.Equal(t, common.CustomCaCertPath, rtCfg.TLS.CABundlePath)
 	assert.False(t, rtCfg.TLS.InsecureSkipVerify)
 }
 


### PR DESCRIPTION
**Description of your changes:**
This PR updates MLflow runtime config generation to always use the mounted runtime CA path (/kfp/certs/ca.crt) instead of the API server-local CA path. It also updates the unit test to validate the new behavior, so driver/launcher can correctly read the CA bundle for TLS connections to MLflow.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [x] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MLflow TLS configuration when using custom CA certificates.
  * Custom certificates are now referenced consistently at runtime, helping secure MLflow connections establish reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->