### PR TITLE
Use rhoai-version tag as managed pipeline version name

### DIFF
--- a/backend/src/apiserver/config/config.go
+++ b/backend/src/apiserver/config/config.go
@@ -352,7 +352,7 @@ func LoadSamples(resourceManager *resource.ResourceManager, sampleConfigPath str
 					glog.Info(fmt.Sprintf("Successfully uploaded PipelineVersion %s.", pvName))
 				}
 
-				if processedPipelines[pvName] {
+				if processedPipelines[p.UUID] {
 					// Since the default sorting is by create time,
 					// Sleep one second makes sure the samples are
 					// showing up in the same order as they are added.
@@ -367,7 +367,7 @@ func LoadSamples(resourceManager *resource.ResourceManager, sampleConfigPath str
 			continue
 		}
 
-		processedPipelines[pvName] = true
+		processedPipelines[p.UUID] = true
 	}
 
 	if !haveSamplesLoaded {

--- a/backend/src/apiserver/config/config.go
+++ b/backend/src/apiserver/config/config.go
@@ -34,6 +34,7 @@ import (
 )
 
 const managedPipelinesUploadTagsEnv = "MANAGED_PIPELINES_UPLOAD_TAGS"
+const managedPipelinesVersionTagKey = "rhoai-version"
 
 var validPipelineName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
@@ -221,6 +222,8 @@ func LoadSamples(resourceManager *resource.ResourceManager, sampleConfigPath str
 		return nil
 	}
 
+	explicitCount := len(pipelineConfig.Pipelines)
+
 	if managedPipelinesDir != "" {
 		existing := make(map[string]bool, len(pipelineConfig.Pipelines))
 		for _, p := range pipelineConfig.Pipelines {
@@ -240,6 +243,12 @@ func LoadSamples(resourceManager *resource.ResourceManager, sampleConfigPath str
 	}
 	if len(tags) > 0 {
 		glog.Infof("Parsed %d managed pipeline upload tag(s) from %s", len(tags), managedPipelinesUploadTagsEnv)
+	}
+
+	if versionFromTag, ok := tags[managedPipelinesVersionTagKey]; ok && versionFromTag != "" {
+		for i := explicitCount; i < len(pipelineConfig.Pipelines); i++ {
+			pipelineConfig.Pipelines[i].VersionName = versionFromTag
+		}
 	}
 
 	processedPipelines := map[string]bool{}

--- a/backend/src/apiserver/config/config.go
+++ b/backend/src/apiserver/config/config.go
@@ -246,6 +246,9 @@ func LoadSamples(resourceManager *resource.ResourceManager, sampleConfigPath str
 	}
 
 	if versionFromTag, ok := tags[managedPipelinesVersionTagKey]; ok && versionFromTag != "" {
+		if len(versionFromTag) > 127 {
+			return fmt.Errorf("%s value %q exceeds PipelineVersion name limit of 127 characters", managedPipelinesVersionTagKey, versionFromTag)
+		}
 		for i := explicitCount; i < len(pipelineConfig.Pipelines); i++ {
 			pipelineConfig.Pipelines[i].VersionName = versionFromTag
 		}

--- a/backend/src/apiserver/config/config_test.go
+++ b/backend/src/apiserver/config/config_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/list"
@@ -1405,6 +1406,30 @@ func TestLoadSamples_ExplicitVersionNameNotOverriddenByTag(t *testing.T) {
 	version, err := rm.GetPipelineVersionByName(managedPipeline.UUID, "3.5.0")
 	require.NoError(t, err, "managed pipeline version should use rhoai-version tag value")
 	assert.Equal(t, "3.5.0", version.DisplayName)
+}
+
+func TestLoadSamples_ManagedVersionNameTooLongReturnsError(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	longVersion := strings.Repeat("x", 128)
+	t.Setenv(managedPipelinesUploadTagsEnv, "managed=true,rhoai-version="+longVersion)
+	rm := fakeResourceManager()
+
+	pc := config{LoadSamplesOnRestart: true, Pipelines: []configPipelines{}}
+	samplePath, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+
+	managedDir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "managed-long", Description: "Long version"},
+	}
+	writeManagedPipelinesManifest(t, managedDir, entries)
+	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "managed-long.yaml"), sampleYAML, 0644))
+
+	err = LoadSamples(rm, samplePath, managedDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds")
 }
 
 func TestLoadSamples_ManagedVersionNameRestartIdempotency(t *testing.T) {

--- a/backend/src/apiserver/config/config_test.go
+++ b/backend/src/apiserver/config/config_test.go
@@ -1237,6 +1237,253 @@ func TestLoadManagedPipelinesManifest_InvalidNamesRejected(t *testing.T) {
 	}
 }
 
+func TestLoadSamples_ManagedVersionNameFromTag(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	t.Setenv(managedPipelinesUploadTagsEnv, "managed=true,rhoai-version=3.5.0")
+	rm := fakeResourceManager()
+
+	pc := config{
+		LoadSamplesOnRestart: true,
+		Pipelines: []configPipelines{
+			{
+				Name:        "Explicit Pipeline",
+				Description: "from sample_config.json",
+				File:        "testdata/sample_pipeline.yaml",
+				VersionName: "Explicit - Ver 1",
+			},
+		},
+	}
+	samplePath, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+
+	managedDir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "managed-a", Description: "Managed A"},
+		{Name: "managed-b", Description: "Managed B"},
+	}
+	writeManagedPipelinesManifest(t, managedDir, entries)
+	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "managed-a.yaml"), sampleYAML, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "managed-b.yaml"), sampleYAML, 0644))
+
+	require.NoError(t, LoadSamples(rm, samplePath, managedDir))
+
+	explicitPipeline, err := rm.GetPipelineByNameAndNamespace("Explicit Pipeline", "")
+	require.NoError(t, err)
+	_, err = rm.GetPipelineVersionByName(explicitPipeline.UUID, "Explicit - Ver 1")
+	require.NoError(t, err, "explicit pipeline version name must not be overridden")
+
+	managedA, err := rm.GetPipelineByNameAndNamespace("managed-a", "")
+	require.NoError(t, err)
+	versionA, err := rm.GetPipelineVersionByName(managedA.UUID, "3.5.0")
+	require.NoError(t, err, "managed pipeline version should use rhoai-version tag value")
+	assert.Equal(t, "3.5.0", versionA.DisplayName)
+
+	managedB, err := rm.GetPipelineByNameAndNamespace("managed-b", "")
+	require.NoError(t, err)
+	versionB, err := rm.GetPipelineVersionByName(managedB.UUID, "3.5.0")
+	require.NoError(t, err, "managed pipeline version should use rhoai-version tag value")
+	assert.Equal(t, "3.5.0", versionB.DisplayName)
+}
+
+func TestLoadSamples_ManagedVersionNameFallbackWithoutTag(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	t.Setenv(managedPipelinesUploadTagsEnv, "managed=true")
+	rm := fakeResourceManager()
+
+	pc := config{LoadSamplesOnRestart: true, Pipelines: []configPipelines{}}
+	samplePath, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+
+	managedDir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "managed-only", Description: "Managed"},
+	}
+	writeManagedPipelinesManifest(t, managedDir, entries)
+	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "managed-only.yaml"), sampleYAML, 0644))
+
+	require.NoError(t, LoadSamples(rm, samplePath, managedDir))
+
+	pipeline, err := rm.GetPipelineByNameAndNamespace("managed-only", "")
+	require.NoError(t, err)
+	_, err = rm.GetPipelineVersionByName(pipeline.UUID, "managed-only")
+	require.NoError(t, err, "without rhoai-version tag, version name should fall back to pipeline name")
+}
+
+func TestLoadSamples_ManagedVersionNameNoTagsEnv(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	t.Setenv(managedPipelinesUploadTagsEnv, "")
+	rm := fakeResourceManager()
+
+	pc := config{LoadSamplesOnRestart: true, Pipelines: []configPipelines{}}
+	samplePath, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+
+	managedDir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "managed-notags", Description: "No tags"},
+	}
+	writeManagedPipelinesManifest(t, managedDir, entries)
+	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "managed-notags.yaml"), sampleYAML, 0644))
+
+	require.NoError(t, LoadSamples(rm, samplePath, managedDir))
+
+	pipeline, err := rm.GetPipelineByNameAndNamespace("managed-notags", "")
+	require.NoError(t, err)
+	_, err = rm.GetPipelineVersionByName(pipeline.UUID, "managed-notags")
+	require.NoError(t, err, "with empty tags env, version name should fall back to pipeline name")
+}
+
+func TestLoadSamples_ManagedVersionNameEmptyTagValue(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	t.Setenv(managedPipelinesUploadTagsEnv, "managed=true,rhoai-version=")
+	rm := fakeResourceManager()
+
+	pc := config{LoadSamplesOnRestart: true, Pipelines: []configPipelines{}}
+	samplePath, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+
+	managedDir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "managed-empty-ver", Description: "Empty version tag"},
+	}
+	writeManagedPipelinesManifest(t, managedDir, entries)
+	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "managed-empty-ver.yaml"), sampleYAML, 0644))
+
+	require.NoError(t, LoadSamples(rm, samplePath, managedDir))
+
+	pipeline, err := rm.GetPipelineByNameAndNamespace("managed-empty-ver", "")
+	require.NoError(t, err)
+	_, err = rm.GetPipelineVersionByName(pipeline.UUID, "managed-empty-ver")
+	require.NoError(t, err, "empty rhoai-version value should fall back to pipeline name")
+}
+
+func TestLoadSamples_ExplicitVersionNameNotOverriddenByTag(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	t.Setenv(managedPipelinesUploadTagsEnv, "managed=true,rhoai-version=3.5.0")
+	rm := fakeResourceManager()
+
+	pc := config{
+		LoadSamplesOnRestart: true,
+		Pipelines: []configPipelines{
+			{
+				Name:        "Explicit With Version",
+				Description: "has its own version",
+				File:        "testdata/sample_pipeline.yaml",
+				VersionName: "my-explicit-version",
+			},
+		},
+	}
+	samplePath, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+
+	managedDir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "managed-tagged", Description: "Tagged"},
+	}
+	writeManagedPipelinesManifest(t, managedDir, entries)
+	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "managed-tagged.yaml"), sampleYAML, 0644))
+
+	require.NoError(t, LoadSamples(rm, samplePath, managedDir))
+
+	explicitPipeline, err := rm.GetPipelineByNameAndNamespace("Explicit With Version", "")
+	require.NoError(t, err)
+	_, err = rm.GetPipelineVersionByName(explicitPipeline.UUID, "my-explicit-version")
+	require.NoError(t, err, "explicit version name must not be overridden by rhoai-version tag")
+
+	managedPipeline, err := rm.GetPipelineByNameAndNamespace("managed-tagged", "")
+	require.NoError(t, err)
+	version, err := rm.GetPipelineVersionByName(managedPipeline.UUID, "3.5.0")
+	require.NoError(t, err, "managed pipeline version should use rhoai-version tag value")
+	assert.Equal(t, "3.5.0", version.DisplayName)
+}
+
+func TestLoadSamples_ManagedVersionNameRestartIdempotency(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	t.Setenv(managedPipelinesUploadTagsEnv, "managed=true,rhoai-version=3.5.0")
+	rm := fakeResourceManager()
+
+	pc := config{LoadSamplesOnRestart: true, Pipelines: []configPipelines{}}
+	samplePath, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+
+	managedDir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "managed-idem", Description: "Idempotency test"},
+	}
+	writeManagedPipelinesManifest(t, managedDir, entries)
+	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "managed-idem.yaml"), sampleYAML, 0644))
+
+	require.NoError(t, LoadSamples(rm, samplePath, managedDir))
+
+	pipeline, err := rm.GetPipelineByNameAndNamespace("managed-idem", "")
+	require.NoError(t, err)
+
+	// Second load with same version — simulates pod restart with same platform version.
+	samplePath, err = writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, samplePath, managedDir))
+
+	opts, err := list.NewOptions(&model.PipelineVersion{}, 10, "id", nil)
+	require.NoError(t, err)
+	_, totalSize, _, err := rm.ListPipelineVersions(pipeline.UUID, opts, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, totalSize, "restart with same rhoai-version must not duplicate the version")
+}
+
+func TestLoadSamples_ManagedVersionNameUpgradeCreatesNewVersion(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	rm := fakeResourceManager()
+
+	pc := config{LoadSamplesOnRestart: true, Pipelines: []configPipelines{}}
+
+	managedDir := t.TempDir()
+	entries := []managedPipelineManifestEntry{
+		{Name: "managed-upgrade", Description: "Upgrade test"},
+	}
+	writeManagedPipelinesManifest(t, managedDir, entries)
+	sampleYAML, err := os.ReadFile("testdata/sample_pipeline.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, "managed-upgrade.yaml"), sampleYAML, 0644))
+
+	// First load: version 3.5.0
+	t.Setenv(managedPipelinesUploadTagsEnv, "managed=true,rhoai-version=3.5.0")
+	samplePath, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, samplePath, managedDir))
+
+	pipeline, err := rm.GetPipelineByNameAndNamespace("managed-upgrade", "")
+	require.NoError(t, err)
+	_, err = rm.GetPipelineVersionByName(pipeline.UUID, "3.5.0")
+	require.NoError(t, err)
+
+	// Second load: upgraded to 3.6.0
+	t.Setenv(managedPipelinesUploadTagsEnv, "managed=true,rhoai-version=3.6.0")
+	samplePath, err = writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, samplePath, managedDir))
+
+	_, err = rm.GetPipelineVersionByName(pipeline.UUID, "3.6.0")
+	require.NoError(t, err, "upgrade should create a new version with the new rhoai-version")
+
+	opts, err := list.NewOptions(&model.PipelineVersion{}, 10, "id", nil)
+	require.NoError(t, err)
+	_, totalSize, _, err := rm.ListPipelineVersions(pipeline.UUID, opts, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, totalSize, "both 3.5.0 and 3.6.0 versions should exist")
+}
+
 func TestLoadManagedPipelinesManifest_ValidNamesAccepted(t *testing.T) {
 	cases := []struct {
 		name      string


### PR DESCRIPTION
## Summary

- Managed pipelines imported via `--managedPipelinesDir` had their version names defaulting to the pipeline name (e.g. `autogluon-tabular-training-pipeline`) instead of the platform version (e.g. `3.5.0`)
- The `MANAGED_PIPELINES_UPLOAD_TAGS` env var already carries `rhoai-version=<version>` — this PR extracts that value and sets it as `VersionName` on managed pipeline entries only, leaving explicit `sample_config.json` entries untouched
- DSP-only change, no DSPO modifications needed

Closes: [RHOAIENG-69371](https://redhat.atlassian.net/browse/RHOAIENG-69371)

## Test plan

- [x] 7 new unit tests covering: happy path, fallback without tag, empty env, empty value, explicit not overridden, restart idempotency, version upgrade
- [x] All existing tests pass unchanged
- [ ] Verify on cluster that managed pipeline versions show the platform version instead of pipeline names

[RHOAIENG-69371]: https://redhat.atlassian.net/browse/RHOAIENG-69371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Managed pipeline versions now use the provided release tag as their version name.
  * Explicitly configured pipeline names remain unchanged.
  * Pipelines fall back to their existing names when no valid release tag is available.
  * Reusing the same release tag is handled consistently, while a changed tag creates a new version.

* **Tests**
  * Added coverage for tagging, fallback behavior, restarts, and upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->