### PR TITLE
Update OWNERS: adjust reviewer/approver roles and consolidate

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-  - hbelmiro
-  - mprahl
-reviewers: []

--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@ approvers:
   - hbelmiro
   - mprahl
   - nsingla
+  - VaniHaripriya
 reviewers:
   - alyssacgoins
   - hbelmiro

--- a/OWNERS
+++ b/OWNERS
@@ -1,17 +1,17 @@
 approvers:
   - accorvin
+  - alyssacgoins
   - dsp-developers
-  - gmfrasca
   - HumairAK
   - hbelmiro
   - mprahl
   - nsingla
 reviewers:
-  - gmfrasca
+  - alyssacgoins
   - hbelmiro
-  - HumairAK
   - VaniHaripriya
-  - mprahl
   - nsingla
+  - sduvvuri1603
 emeritus_approvers:
+  - gmfrasca
   - harshad16

--- a/backend/OWNERS
+++ b/backend/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-  - hbelmiro
-  - mprahl
-reviewers:
-  - hbelmiro
-  - HumairAK
-  - mprahl
-  - gmfrasca

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-  - HumairAK
-reviewers:
-  - mprahl

--- a/test_data/OWNERS
+++ b/test_data/OWNERS
@@ -1,7 +1,0 @@
-approvers:
-  - hbelmiro
-  - mprahl
-  - nsingla
-reviewers:
-  - gmfrasca
-  - nsingla

--- a/tools/OWNERS
+++ b/tools/OWNERS
@@ -1,5 +1,0 @@
-approvers:
-  - HumairAK
-reviewers:
-  - mprahl
-  - hbelmiro


### PR DESCRIPTION
## Summary
- **HumairAK** and **mprahl**: changed to approver-only (removed from reviewers)
- **gmfrasca**: moved to emeritus_approvers
- **VaniHaripriya**: added as approver
- **alyssacgoins**: added as approver + reviewer
- **sduvvuri1603**: added as reviewer
- Removed subdirectory OWNERS files (`backend/`, `test/`, `tools/`, `test_data/`, `.github/`) as they only restricted permissions already granted by the root OWNERS file

## Test plan
- [x] Verified no subdirectory OWNERS file granted broader permissions than root
- [x] Verified DSPO and pipelines-components already have correct roles