### PR TITLE
Fix cross-architecture wget binary in apiserver Dockerfile

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -47,6 +47,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
+      - name: Set up QEMU
+        if: matrix.target_arch != 'arm64'
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
+        with:
+          platforms: ${{ matrix.target_arch }}
       - name: Build ${{ matrix.image.name }} (${{ matrix.target_arch }})
         run: make -C backend ${{ matrix.image.make_target }} BUILDER_ARCH=arm64 TARGETARCH=${{ matrix.target_arch }} ${{ matrix.image.img_tag_var }}=localhost/${{ matrix.image.name }}:${{ matrix.target_arch }}
       - name: Verify ${{ matrix.target_arch }} image architecture

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -94,10 +94,10 @@ RUN set -e; \
     echo "Compiling: \"$pipeline_py\"" && python3 "$pipeline_py" && echo -n "Output: " && ls "$pipeline_py.yaml"; \
     done
 
-# 3. Install runtime dependencies on the build host architecture
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:865c6a875328a1174ff7f17599574412edd327aa47812951b9bead902806dc53 AS ubi-minimal-multiarch
+# 3. Install runtime dependencies for the target architecture
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:865c6a875328a1174ff7f17599574412edd327aa47812951b9bead902806dc53 AS ubi-minimal-amd64
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:da229086eb7881bb653e99ace537fc03512bbbfcf14024e7e447b48015d7cc8c AS ubi-minimal-arm64
-FROM ubi-minimal-${BUILDER_ARCH} AS runtime-deps
+FROM ubi-minimal-${TARGETARCH} AS runtime-deps
 RUN microdnf install -y ca-certificates wget && microdnf clean all
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5


### PR DESCRIPTION
## Summary

- Fixes the `runtime-deps` stage in `backend/Dockerfile` to select its base image by `TARGETARCH` instead of `BUILDER_ARCH`, preventing a wrong-architecture `wget` binary from being copied into the final image during cross-compilation
- Renames the `ubi-minimal-multiarch` alias to the more accurate `ubi-minimal-amd64` since the digest is amd64-specific

## Details

When cross-compiling (e.g., `BUILDER_ARCH=arm64`, `TARGETARCH=amd64`), the `runtime-deps` stage was keyed on `BUILDER_ARCH`, installing `wget` for the builder's architecture. That binary was then copied into the final stage running on `TARGETARCH`, causing `exec format error` on the liveness/readiness probe and continuous pod restarts.

The Go binary was unaffected (Go cross-compiles correctly via Zig), and `/etc/pki` (CA certificates) is data-only and architecture-independent. Only the `wget` binary copy was broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image builds for both AMD64 and ARM64 by selecting runtime dependencies based on the intended target architecture.
  * Enhanced cross-platform build reliability by conditionally setting up QEMU for non–ARM64 targets and validating the resulting image architecture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->