### PR TITLE
UPSTREAM: <carry>: fix(backend): tolerate task-level MLflow outages

### DIFF
--- a/backend/src/v2/common/plugins/dispatcher.go
+++ b/backend/src/v2/common/plugins/dispatcher.go
@@ -125,6 +125,13 @@ func (t *TaskPluginDispatcherImpl) RetrieveUserContainerEnvVars(taskInfo *TaskIn
 
 	injectVarNameSet := map[string]bool{}
 	for _, handler := range t.handlers {
+		if t.startedHandlers != nil && !t.startedHandlers[handler.Name()] {
+			glog.Infof(
+				"Skipping user container env vars for handler %s (OnTaskStart did not succeed)",
+				handler.Name(),
+			)
+			continue
+		}
 		vars, err := handler.RetrieveUserContainerEnvVars()
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve user container env vars for handler %s: %v", handler.Name(), err)

--- a/backend/src/v2/common/plugins/dispatcher_test.go
+++ b/backend/src/v2/common/plugins/dispatcher_test.go
@@ -278,6 +278,31 @@ func TestRetrieveUserContainerEnvVars_Success(t *testing.T) {
 	assert.Equal(t, expectedVars, vars)
 }
 
+func TestRetrieveUserContainerEnvVars_SkipsFailedHandler(t *testing.T) {
+	expectedVars := []corev1.EnvVar{
+		{Name: "PLUGIN_RUN_ID", Value: "fake-run-1"},
+	}
+	failedHandler := &fakeHandler{
+		name:     "FailedPlugin",
+		startErr: fmt.Errorf("plugin startup failed"),
+		envErr:   fmt.Errorf("env var retrieval should be skipped"),
+	}
+	successfulHandler := &fakeHandler{
+		name:    "SuccessfulPlugin",
+		envVars: expectedVars,
+	}
+	dispatcher, _ := NewTaskPluginDispatcherImpl(
+		[]TaskPluginHandler{failedHandler, successfulHandler},
+	)
+
+	_, err := dispatcher.OnTaskStart(context.Background(), taskInfoStart)
+	require.NoError(t, err)
+	vars, err := dispatcher.RetrieveUserContainerEnvVars(taskInfoEnd)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedVars, vars)
+}
+
 func TestRetrieveUserContainerEnvVars_HandlerError_Propagated(t *testing.T) {
 	handler := &fakeHandler{
 		name:   "FakePlugin",


### PR DESCRIPTION
**Description of your changes:**

Carries kubeflow/pipelines#13938.

Treat task-level MLflow integration as best-effort when a plugin cannot
start. The task plugin dispatcher skips user container environment variable
retrieval for handlers whose `OnTaskStart` call failed. This lets user
containers run during an MLflow outage while preserving environment variables
from plugins that started successfully.

`injectUserEnvVars` controls whether MLflow integration context is exposed; it
does not make MLflow availability a pipeline requirement. Components using
optional MLflow instrumentation can guard it with:

```python
if os.getenv("MLFLOW_RUN_ID"):
    mlflow.autolog()
```

Environment variable construction errors from successfully started plugins
still propagate.

Tests:

- Task plugin dispatcher tests: 20 passed
- MLflow task handler tests: 31 passed

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) follows the repository title
  convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task startup reliability by preventing environment variable retrieval from failed task handlers.
  * Ensured environment variables are collected only from handlers that successfully start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->