### PR TITLE
fix(ci): repair API server test deployments

### DIFF
--- a/.github/resources/manifests/base/ci-stability-tuning.yaml
+++ b/.github/resources/manifests/base/ci-stability-tuning.yaml
@@ -16,21 +16,3 @@ spec:
           startupProbe:
             failureThreshold: 24
             timeoutSeconds: 5
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: seaweedfs
-  namespace: kubeflow
-spec:
-  template:
-    spec:
-      containers:
-        - name: seaweedfs
-          resources:
-            requests:
-              cpu: 250m
-              memory: 512Mi
-            limits:
-              cpu: "1"
-              memory: 1Gi

--- a/.github/resources/manifests/base/seaweedfs-ci-stability-tuning.yaml
+++ b/.github/resources/manifests/base/seaweedfs-ci-stability-tuning.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seaweedfs
+  namespace: kubeflow
+spec:
+  template:
+    spec:
+      containers:
+        - name: seaweedfs
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi

--- a/.github/resources/manifests/kubernetes-native/default/kustomization.yaml
+++ b/.github/resources/manifests/kubernetes-native/default/kustomization.yaml
@@ -43,6 +43,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/multiuser/artifact-proxy/kustomization.yaml
+++ b/.github/resources/manifests/multiuser/artifact-proxy/kustomization.yaml
@@ -47,6 +47,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/multiuser/cache-disabled/kustomization.yaml
+++ b/.github/resources/manifests/multiuser/cache-disabled/kustomization.yaml
@@ -47,6 +47,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: cache-env.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/multiuser/default/kustomization.yaml
+++ b/.github/resources/manifests/multiuser/default/kustomization.yaml
@@ -47,6 +47,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/cache-disabled-tls/kustomization.yaml
+++ b/.github/resources/manifests/standalone/cache-disabled-tls/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../tls-enabled
+
+patches:
+  - path: ../cache-disabled/cache-env.yaml
+    target:
+      kind: Deployment
+      name: ml-pipeline

--- a/.github/resources/manifests/standalone/cache-disabled/kustomization.yaml
+++ b/.github/resources/manifests/standalone/cache-disabled/kustomization.yaml
@@ -43,6 +43,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: cache-env.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/default/kustomization.yaml
+++ b/.github/resources/manifests/standalone/default/kustomization.yaml
@@ -43,6 +43,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/proxy/kustomization.yaml
+++ b/.github/resources/manifests/standalone/proxy/kustomization.yaml
@@ -43,6 +43,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: apiserver-env.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/tls-enabled/kustomization.yaml
+++ b/.github/resources/manifests/standalone/tls-enabled/kustomization.yaml
@@ -43,6 +43,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: apiserver-env.yaml
     target:
       kind: Deployment

--- a/.github/resources/scripts/deploy-kfp.sh
+++ b/.github/resources/scripts/deploy-kfp.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Remove the x if you need no print out of each command
-set -e
+set -eo pipefail
 
 REGISTRY="${REGISTRY:-kind-registry:5000}"
 EXIT_CODE=0
@@ -135,6 +135,8 @@ if [ "${MULTI_USER}" == "false" ] && [ "${PIPELINES_STORE}" != "kubernetes" ]; t
   TEST_MANIFESTS="${TEST_MANIFESTS}/standalone"
   if $CACHE_DISABLED && $USE_PROXY; then
     TEST_MANIFESTS="${TEST_MANIFESTS}/cache-disabled-proxy"
+  elif $CACHE_DISABLED && $POD_TO_POD_TLS_ENABLED; then
+    TEST_MANIFESTS="${TEST_MANIFESTS}/cache-disabled-tls"
   elif $CACHE_DISABLED; then
     TEST_MANIFESTS="${TEST_MANIFESTS}/cache-disabled"
   elif $USE_PROXY; then

--- a/.github/workflows/api-server-tests.yml
+++ b/.github/workflows/api-server-tests.yml
@@ -132,6 +132,7 @@ jobs:
           if [ "${{ env.SKIP_OPERATOR_DEPLOYMENT }}" == "false" ]; then
             kubectl get configmap openshift-service-ca.crt -n kubeflow -o jsonpath='{.data.service-ca\.crt}' > "${{ github.workspace }}/ca.crt"
           else
+            kubectl wait --for=condition=Ready certificate/kfp-api-tls-cert -n kubeflow --timeout=120s
             kubectl get secret kfp-api-tls-cert -n kubeflow -o jsonpath='{.data.ca\.crt}' | base64 -d > "${{ github.workspace }}/ca.crt"
           fi
           echo "CA_CERT_PATH=${{ github.workspace }}/ca.crt" >> "$GITHUB_ENV"


### PR DESCRIPTION
**Description of your changes:**

Port the CI baseline repair from
red-hat-data-services/data-science-pipelines#1603.

The standalone API server matrix enables cache-disabled and pod-to-pod TLS
together, but the deploy script previously selected only the cache-disabled
overlay. Add a composed overlay so those jobs deploy TLS certificate resources
and disable execution caching. Wait for cert-manager to mark the Certificate
Ready before reading its generated Secret.

Older Kustomize releases also reject the multi-document CI stability patch.
Split it into one resource per patch file and update every consumer. Enable
`pipefail` so Kustomize render failures are not masked by `kubectl apply`.

Validation:

- All nine affected overlays render with Kustomize 5.0.1.
- The combined overlay contains `Certificate/kfp-api-tls-cert`.
- The combined overlay sets `CACHEENABLED=false`.
- ShellCheck passes for the deployment script.

**Checklist:**
- [x] The commit is signed off
- [x] The title follows the repository convention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by propagating failures through deployment command pipelines.
  * Added support for cache-disabled deployments with pod-to-pod TLS.
  * Ensured TLS certificate readiness before retrieving certificate data in API server tests.
  * Applied consistent SeaweedFS resource tuning across deployment configurations.
* **Tests**
  * Updated deployment test configuration to use the appropriate TLS and cache settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->