### PR TITLE
fix: exclude TLS security scans from CI gate

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -54,11 +54,13 @@ jobs:
           delay: '5'
           retries: '10'
           polling_interval: '5'
-          # Exclude checks dynamically created by the GitHub Copilot pull request reviewer.
-          # These checks fail with HTTP 403 on fork PRs due to permission limitations,
-          # causing false negatives in the status gate. If the Copilot reviewer adds or
-          # renames checks, update this list accordingly.
-          checks_exclude: '^Cleanup artifacts$,^Upload results$,^Agent$,^Prepare$'
+          # Exclude checks that should not block the CI gate:
+          # - Copilot reviewer checks: fail with HTTP 403 on fork PRs
+          # - TLS security scans (tls-lint, semgrep-tls): informational checks
+          #   synced from opendatahub-io/security-config, report pre-existing
+          #   findings from upstream code (fixed in kubeflow/pipelines#13609,
+          #   will resolve on next rebase)
+          checks_exclude: '^Cleanup artifacts$,^Upload results$,^Agent$,^Prepare$,^tls-lint$,^semgrep-tls$,^TLS Config Lint$,^Semgrep TLS Rules$'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The `tls-lint` and `semgrep-tls` checks are informational security scans synced from [opendatahub-io/security-config](https://github.com/opendatahub-io/security-config). They currently flag pre-existing TLS findings in upstream code, which blocks the `CI Check` workflow from passing and prevents tide from merging PRs (including the sync PR [#275](https://github.com/opendatahub-io/data-science-pipelines/pull/275)).

The upstream fixes already exist in [kubeflow/pipelines#13609](https://github.com/kubeflow/pipelines/pull/13609). The findings will resolve once the next rebase sync picks up that commit.

This PR excludes both TLS checks from the `allcheckspassed` gate so they remain visible as informational checks without blocking merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI status checks to exclude TLS lint and security checks from blocking results.
  * Documented the handling of these non-blocking checks and related findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->